### PR TITLE
Fix FD leak in static resource serving

### DIFF
--- a/src/jetzig/http/Server.zig
+++ b/src/jetzig/http/Server.zig
@@ -371,7 +371,9 @@ fn matchStaticResource(self: *Self, request: *jetzig.http.Request) !?StaticResou
             else => return err,
         }
     };
+    defer iterable_dir.close();
     var walker = try iterable_dir.walk(request.allocator);
+    defer walker.deinit();
     while (try walker.next()) |file| {
         if (file.kind != .file) continue;
 


### PR DESCRIPTION
Currently, jetzig leaks at least one file descriptior per static resource it serves. If the public directory contains subdirectories, it potentially leaks one FD per subdirectory.

To reproduce the issue, either check with `lsof` (e.g. `lsof -c jetzig`) after doing some requests or start a jetzig app in a shell with a limit on open files (e.g. run `ulimit -n 128` before running the jetzig app).