### PR TITLE
std.http overhaul

### DIFF
--- a/demo/src/DemoMiddleware.zig
+++ b/demo/src/DemoMiddleware.zig
@@ -12,13 +12,13 @@ pub fn init(request: *jetzig.http.Request) !*Self {
 }
 
 pub fn beforeRequest(self: *Self, request: *jetzig.http.Request) !void {
-    request.server.logger.debug("[middleware] Before request, custom data: {d}", .{self.my_data});
+    request.server.logger.debug("[DemoMiddleware] Before request, custom data: {d}", .{self.my_data});
     self.my_data = 43;
 }
 
 pub fn afterRequest(self: *Self, request: *jetzig.http.Request, response: *jetzig.http.Response) !void {
-    request.server.logger.debug("[middleware] After request, custom data: {d}", .{self.my_data});
-    request.server.logger.debug("[middleware] content-type: {s}", .{response.content_type});
+    request.server.logger.debug("[DemoMiddleware] After request, custom data: {d}", .{self.my_data});
+    request.server.logger.debug("[DemoMiddleware] content-type: {s}", .{response.content_type});
 }
 
 pub fn deinit(self: *Self, request: *jetzig.http.Request) void {

--- a/demo/src/app/views/quotes.zig
+++ b/demo/src/app/views/quotes.zig
@@ -18,8 +18,10 @@ pub fn get(id: []const u8, request: *jetzig.Request, data: *jetzig.Data) !jetzig
 }
 
 pub fn post(request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
-    _ = data;
+    var root = try data.object();
     const params = try request.params();
+    try root.put("param", params.get("foo").?);
+
     std.debug.print("{}\n", .{params});
     return request.render(.ok);
 }

--- a/src/jetzig.zig
+++ b/src/jetzig.zig
@@ -33,6 +33,7 @@ pub const View = views.View;
 pub const config = struct {
     pub const max_bytes_request_body: usize = std.math.pow(usize, 2, 16);
     pub const max_bytes_static_content: usize = std.math.pow(usize, 2, 16);
+    pub const http_buffer_size: usize = std.math.pow(usize, 2, 16);
     pub const public_content = .{ .path = "public" };
 };
 

--- a/src/jetzig/App.zig
+++ b/src/jetzig/App.zig
@@ -18,29 +18,45 @@ pub fn deinit(self: Self) void {
 /// Starts an application. `routes` should be `@import("routes").routes`, a generated file
 /// automatically created at build time. `templates` should be
 /// `@import("src/app/views/zmpl.manifest.zig").templates`, created by Zmpl at compile time.
-pub fn start(self: Self, routes: []jetzig.views.Route, templates: []jetzig.TemplateFn) !void {
+pub fn start(self: Self, comptime_routes: []jetzig.views.Route, templates: []jetzig.TemplateFn) !void {
     var mime_map = jetzig.http.mime.MimeMap.init(self.allocator);
     defer mime_map.deinit();
     try mime_map.build();
+
+    var routes = std.ArrayList(*jetzig.views.Route).init(self.allocator);
+
+    for (comptime_routes) |*comptime_route| {
+        var route = try self.allocator.create(jetzig.views.Route);
+        route.* = jetzig.views.Route{
+            .name = comptime_route.name,
+            .action = comptime_route.action,
+            .uri_path = comptime_route.uri_path,
+            .view = comptime_route.view,
+            .static_view = comptime_route.static_view,
+            .static = comptime_route.static,
+            .render = comptime_route.render,
+            .renderStatic = comptime_route.renderStatic,
+            .template = comptime_route.template,
+            .json_params = comptime_route.json_params,
+        };
+        try route.initParams(self.allocator);
+        try routes.append(route);
+    }
+    defer routes.deinit();
+    defer for (routes.items) |route| {
+        route.deinitParams();
+        self.allocator.destroy(route);
+    };
 
     var server = jetzig.http.Server.init(
         self.allocator,
         self.host,
         self.port,
         self.server_options,
-        routes,
+        routes.items,
         templates,
         &mime_map,
     );
-
-    for (routes) |*route| {
-        var mutable = @constCast(route); // FIXME
-        try mutable.initParams(self.allocator);
-    }
-    defer for (routes) |*route| {
-        var mutable = @constCast(route); // FIXME
-        mutable.deinitParams();
-    };
 
     defer server.deinit();
     defer self.allocator.free(self.root_path);

--- a/src/jetzig/http/Headers.zig
+++ b/src/jetzig/http/Headers.zig
@@ -1,35 +1,44 @@
 const std = @import("std");
 
 allocator: std.mem.Allocator,
-std_headers: std.http.Headers,
+headers: HeadersArray,
 
 const Self = @This();
+pub const max_headers = 25;
+const HeadersArray = std.ArrayListUnmanaged(std.http.Header);
 
-pub fn init(allocator: std.mem.Allocator, headers: std.http.Headers) Self {
-    return .{ .allocator = allocator, .std_headers = headers };
+pub fn init(allocator: std.mem.Allocator) Self {
+    return .{
+        .allocator = allocator,
+        .headers = HeadersArray.initCapacity(allocator, max_headers) catch @panic("OOM"),
+    };
 }
 
 pub fn deinit(self: *Self) void {
-    self.std_headers.deinit();
+    self.headers.deinit();
 }
 
 // Gets the first value for a given header identified by `name`.
 pub fn getFirstValue(self: *Self, name: []const u8) ?[]const u8 {
-    return self.std_headers.getFirstValue(name);
+    for (self.headers.items) |header| {
+        if (std.mem.eql(u8, header.name, name)) return header.value;
+    }
+    return null;
 }
 
 /// Appends `name` and `value` to headers.
 pub fn append(self: *Self, name: []const u8, value: []const u8) !void {
-    try self.std_headers.append(name, value);
+    self.headers.appendAssumeCapacity(.{ .name = name, .value = value });
 }
 
 /// Returns an iterator which implements `next()` returning each name/value of the stored headers.
 pub fn iterator(self: *Self) Iterator {
-    return Iterator{ .std_headers = self.std_headers };
+    return Iterator{ .headers = self.headers };
 }
 
+/// Iterates through stored headers yielidng a `Header` on each call to `next()`
 const Iterator = struct {
-    std_headers: std.http.Headers,
+    headers: HeadersArray,
     index: usize = 0,
 
     const Header = struct {
@@ -39,8 +48,8 @@ const Iterator = struct {
 
     /// Returns the next item in the current iteration of headers.
     pub fn next(self: *Iterator) ?Header {
-        if (self.std_headers.list.items.len > self.index) {
-            const std_header = self.std_headers.list.items[self.index];
+        if (self.headers.items.len > self.index) {
+            const std_header = self.headers.items[self.index];
             self.index += 1;
             return .{ .name = std_header.name, .value = std_header.value };
         } else {

--- a/src/jetzig/http/Request.zig
+++ b/src/jetzig/http/Request.zig
@@ -15,22 +15,24 @@ method: Method,
 headers: jetzig.http.Headers,
 segments: std.ArrayList([]const u8),
 server: *jetzig.http.Server,
-session: *jetzig.http.Session,
+std_http_request: std.http.Server.Request,
 response: *jetzig.http.Response,
 status_code: jetzig.http.status_codes.StatusCode = undefined,
 response_data: *jetzig.data.Data,
 query_data: *jetzig.data.Data,
 query: *jetzig.http.Query,
-cookies: *jetzig.http.Cookies,
-body: []const u8,
+cookies: *jetzig.http.Cookies = undefined,
+session: *jetzig.http.Session = undefined,
+body: []const u8 = undefined,
+processed: bool = false,
 
 pub fn init(
     allocator: std.mem.Allocator,
     server: *jetzig.http.Server,
+    std_http_request: std.http.Server.Request,
     response: *jetzig.http.Response,
-    body: []const u8,
 ) !Self {
-    const method = switch (response.std_response.request.method) {
+    const method = switch (std_http_request.head.method) {
         .DELETE => Method.DELETE,
         .GET => Method.GET,
         .PATCH => Method.PATCH,
@@ -50,7 +52,7 @@ pub fn init(
     // * Extension: "/foo/bar/baz/1.json" => ".json"
     // * Query params: "/foo/bar/baz?foo=bar&baz=qux" => .{ .foo = "bar", .baz => "qux" }
     // * Anything else ?
-    var it = std.mem.splitScalar(u8, response.std_response.request.target, '/');
+    var it = std.mem.splitScalar(u8, std_http_request.head.target, '/');
     var segments = std.ArrayList([]const u8).init(allocator);
     while (it.next()) |segment| {
         if (std.mem.indexOfScalar(u8, segment, '?')) |query_index| {
@@ -59,25 +61,6 @@ pub fn init(
             try segments.append(segment);
         }
     }
-
-    var cookies = try allocator.create(jetzig.http.Cookies);
-    cookies.* = jetzig.http.Cookies.init(
-        allocator,
-        response.std_response.request.headers.getFirstValue("Cookie") orelse "",
-    );
-    try cookies.parse();
-
-    var session = try allocator.create(jetzig.http.Session);
-    session.* = jetzig.http.Session.init(allocator, cookies, server.options.secret);
-    session.parse() catch |err| {
-        switch (err) {
-            error.JetzigInvalidSessionCookie => {
-                server.logger.debug("Invalid session cookie detected. Resetting session.", .{});
-                try session.reset();
-            },
-            else => return err,
-        }
-    };
 
     const response_data = try allocator.create(jetzig.data.Data);
     response_data.* = jetzig.data.Data.init(allocator);
@@ -89,26 +72,82 @@ pub fn init(
 
     return .{
         .allocator = allocator,
-        .path = response.std_response.request.target,
+        .path = std_http_request.head.target,
         .method = method,
-        .headers = jetzig.http.Headers.init(allocator, response.std_response.request.headers),
+        .headers = jetzig.http.Headers.init(allocator),
         .server = server,
         .segments = segments,
-        .cookies = cookies,
-        .session = session,
+        .response = response,
         .response_data = response_data,
         .query_data = query_data,
         .query = query,
-        .body = body,
-        .response = response,
+        .std_http_request = std_http_request,
     };
 }
 
 pub fn deinit(self: *Self) void {
-    self.session.deinit();
+    // self.session.deinit();
     self.segments.deinit();
     self.allocator.destroy(self.cookies);
     self.allocator.destroy(self.session);
+    if (self.processed) self.allocator.free(self.body);
+}
+
+/// Process request, read body if present, parse headers (TODO)
+pub fn process(self: *Self) !void {
+    var headers_it = self.std_http_request.iterateHeaders();
+    var cookie: ?[]const u8 = null;
+
+    while (headers_it.next()) |header| {
+        try self.headers.append(header.name, header.value);
+        if (std.mem.eql(u8, header.name, "Cookie")) cookie = header.value;
+    }
+
+    self.cookies = try self.allocator.create(jetzig.http.Cookies);
+    self.cookies.* = jetzig.http.Cookies.init(
+        self.allocator,
+        cookie orelse "",
+    );
+    try self.cookies.parse();
+
+    self.session = try self.allocator.create(jetzig.http.Session);
+    self.session.* = jetzig.http.Session.init(self.allocator, self.cookies, self.server.options.secret);
+    self.session.parse() catch |err| {
+        switch (err) {
+            error.JetzigInvalidSessionCookie => {
+                self.server.logger.debug("Invalid session cookie detected. Resetting session.", .{});
+                try self.session.reset();
+            },
+            else => return err,
+        }
+    };
+
+    const reader = try self.std_http_request.reader();
+    self.body = try reader.readAllAlloc(self.allocator, jetzig.config.max_bytes_request_body);
+    self.processed = true;
+}
+
+/// Set response headers, write response payload, and finalize the response.
+pub fn respond(self: *Self) !void {
+    if (!self.processed) unreachable;
+
+    var cookie_it = self.cookies.headerIterator();
+    while (try cookie_it.next()) |header| {
+        // FIXME: Skip setting cookies that are already present ?
+        try self.response.headers.append("Set-Cookie", header);
+    }
+
+    // TODO: Move to jetzig.http.Response.stdHeaders()
+    var std_response_headers = std.ArrayList(std.http.Header).init(self.allocator);
+    var headers_it = self.response.headers.iterator();
+    while (headers_it.next()) |header| try std_response_headers.append(
+        .{ .name = header.name, .value = header.value },
+    );
+
+    try self.std_http_request.respond(
+        self.response.content,
+        .{ .keep_alive = false, .extra_headers = std_response_headers.items },
+    );
 }
 
 pub fn render(self: *Self, status_code: jetzig.http.status_codes.StatusCode) jetzig.views.View {
@@ -129,6 +168,8 @@ pub fn getHeader(self: *Self, key: []const u8) ?[]const u8 {
 /// otherwise the parsed JSON request body will take precedence and query parameters will be
 /// ignored.
 pub fn params(self: *Self) !*jetzig.data.Value {
+    if (!self.processed) unreachable;
+
     switch (self.requestFormat()) {
         .JSON => {
             if (self.body.len == 0) return self.queryParams();
@@ -137,7 +178,7 @@ pub fn params(self: *Self) !*jetzig.data.Value {
             data.* = jetzig.data.Data.init(self.allocator);
             data.fromJson(self.body) catch |err| {
                 switch (err) {
-                    error.UnexpectedEndOfInput => return error.JetzigBodyParseError,
+                    error.SyntaxError, error.UnexpectedEndOfInput => return error.JetzigBodyParseError,
                     else => return err,
                 }
             };
@@ -253,22 +294,30 @@ pub fn resourceId(self: *Self) []const u8 {
 
 // Determine if a given route matches the current request.
 pub fn match(self: *Self, route: jetzig.views.Route) !bool {
-    switch (self.method) {
-        .GET => {
-            return switch (route.action) {
-                .index => self.isMatch(.exact, route),
-                .get => self.isMatch(.resource_id, route),
-                else => false,
-            };
+    return switch (self.method) {
+        .GET => switch (route.action) {
+            .index => self.isMatch(.exact, route),
+            .get => self.isMatch(.resource_id, route),
+            else => false,
         },
-        .POST => return self.isMatch(.exact, route),
-        .PUT => return self.isMatch(.resource_id, route),
-        .PATCH => return self.isMatch(.resource_id, route),
-        .DELETE => return self.isMatch(.resource_id, route),
-        else => return false,
-    }
-
-    return false;
+        .POST => switch (route.action) {
+            .post => self.isMatch(.exact, route),
+            else => false,
+        },
+        .PUT => switch (route.action) {
+            .put => self.isMatch(.resource_id, route),
+            else => false,
+        },
+        .PATCH => switch (route.action) {
+            .patch => self.isMatch(.resource_id, route),
+            else => false,
+        },
+        .DELETE => switch (route.action) {
+            .delete => self.isMatch(.resource_id, route),
+            else => false,
+        },
+        .HEAD, .CONNECT, .OPTIONS, .TRACE => false,
+    };
 }
 
 fn isMatch(self: *Self, match_type: enum { exact, resource_id }, route: jetzig.views.Route) bool {

--- a/src/jetzig/http/Response.zig
+++ b/src/jetzig/http/Response.zig
@@ -5,7 +5,6 @@ const http = @import("../http.zig");
 const Self = @This();
 
 allocator: std.mem.Allocator,
-std_response: *std.http.Server.Response,
 headers: *jetzig.http.Headers,
 content: []const u8,
 status_code: http.status_codes.StatusCode,
@@ -13,14 +12,12 @@ content_type: []const u8,
 
 pub fn init(
     allocator: std.mem.Allocator,
-    std_response: *std.http.Server.Response,
 ) !Self {
     const headers = try allocator.create(jetzig.http.Headers);
-    headers.* = jetzig.http.Headers.init(allocator, std_response.headers);
+    headers.* = jetzig.http.Headers.init(allocator);
 
     return .{
         .allocator = allocator,
-        .std_response = std_response,
         .status_code = .no_content,
         .content_type = "application/octet-stream",
         .content = "",
@@ -32,54 +29,4 @@ pub fn deinit(self: *const Self) void {
     self.headers.deinit();
     self.allocator.destroy(self.headers);
     self.std_response.deinit();
-}
-
-const ResetState = enum { reset, closing };
-
-/// Resets the current connection.
-pub fn reset(self: *const Self) ResetState {
-    return switch (self.std_response.reset()) {
-        .reset => .reset,
-        .closing => .closing,
-    };
-}
-
-/// Waits for the current request to finish sending.
-pub fn wait(self: *const Self) !void {
-    try self.std_response.wait();
-}
-
-/// Finalizes a request. Appends any stored headers, sets the response status code, and writes
-/// the response body.
-pub fn finish(self: *const Self) !void {
-    self.std_response.status = switch (self.status_code) {
-        inline else => |status_code| @field(std.http.Status, @tagName(status_code)),
-    };
-
-    var it = self.headers.iterator();
-    while (it.next()) |header| {
-        try self.std_response.headers.append(header.name, header.value);
-    }
-
-    try self.std_response.send();
-    try self.std_response.writeAll(self.content);
-    try self.std_response.finish();
-}
-
-/// Reads the current request body. Caller owns memory.
-pub fn read(self: *const Self) ![]const u8 {
-    return try self.std_response.reader().readAllAlloc(self.allocator, jetzig.config.max_bytes_request_body);
-}
-
-const TransferEncodingOptions = struct {
-    content_length: usize,
-};
-
-/// Sets the transfer encoding for the current response (content length/chunked encoding).
-/// ```
-/// setTransferEncoding(.{ .content_length = 1000 });
-/// ```
-pub fn setTransferEncoding(self: *const Self, transfer_encoding: TransferEncodingOptions) void {
-    // TODO: Chunked encoding
-    self.std_response.transfer_encoding = .{ .content_length = transfer_encoding.content_length };
 }

--- a/src/jetzig/http/middleware.zig
+++ b/src/jetzig/http/middleware.zig
@@ -40,7 +40,6 @@ pub fn beforeMiddleware(request: *jetzig.http.Request) !MiddlewareData {
 pub fn afterMiddleware(
     middleware_data: *MiddlewareData,
     request: *jetzig.http.Request,
-    response: *jetzig.http.Response,
 ) !void {
     inline for (middlewares, 0..) |middleware, index| {
         if (comptime !@hasDecl(middleware, "afterRequest")) continue;
@@ -49,10 +48,10 @@ pub fn afterMiddleware(
             try @call(
                 .always_inline,
                 middleware.afterRequest,
-                .{ @as(*middleware, @ptrCast(@alignCast(data))), request, response },
+                .{ @as(*middleware, @ptrCast(@alignCast(data))), request, request.response },
             );
         } else {
-            try @call(.always_inline, middleware.afterRequest, .{ request, response });
+            try @call(.always_inline, middleware.afterRequest, .{ request, request.response });
         }
     }
 }

--- a/src/jetzig/views/Route.zig
+++ b/src/jetzig/views/Route.zig
@@ -61,7 +61,10 @@ pub fn initParams(self: *Self, allocator: std.mem.Allocator) !void {
 }
 
 pub fn deinitParams(self: *const Self) void {
-    for (self.params.items) |data| data.deinit();
+    for (self.params.items) |data| {
+        data.deinit();
+        data._allocator.destroy(data);
+    }
     self.params.deinit();
 }
 


### PR DESCRIPTION
Andrew overhauled std.http to avoid allocations and put control of connection + stream into hands of users. For now, do a barebones implementation to restore compatibility, later we can do keepalive and pipelining. For now, still getting decent enough performance the "slow" way.

Relevant commit: https://github.com/ziglang/zig/commit/6395ba852a88f0e0b2a2f0659f1daf9d08e90157

Commit message copied here for posterity:

> Author: Andrew Kelley <andrew@ziglang.org>
> Date:   Tue Feb 20 03:30:51 2024 -0700
> std.http.Server: rework the API entirely
> Mainly, this removes the poorly named `wait`, `send`, `finish`
> functions, which all operated on the same "Response" object, which was
> actually being used as the request.
>
> Now, it looks like this:
> 1. std.net.Server.accept() gives you a std.net.Server.Connection
> 2. std.http.Server.init() with the connection
> 3. Server.receiveHead() gives you a Request
> 4. Request.reader() gives you a body reader
> 5. Request.respond() is a one-shot, or Request.respondStreaming() creates
>    a Response
> 6. Response.writer() gives you a body writer
> 7. Response.end() finishes the response; Response.endChunked() allows
>    passing response trailers.
>
> In other words, the type system now guides the API user down the correct
> path.
>
> receiveHead allows extra bytes to be read into the read buffer, and then
> will reuse those bytes for the body or the next request upon connection
> reuse.
>
> respond(), the one-shot function, will send the entire response in one
> syscall.
>
> Streaming response bodies no longer wastefully wraps every call to write
> with a chunk header and trailer; instead it only sends the HTTP chunk
> wrapper when flushing. This means the user can still control when it
> happens but it also does not add unnecessary chunks.
>
> Empirically, in my example project that uses this API, the usage code is
> significantly less noisy, it has less error handling while handling
> errors more correctly, it's more obvious what is happening, and it is
> syscall-optimal.
>
> Additionally:
> * Uncouple std.http.HeadParser from protocol.zig
> * Delete std.Server.Connection; use std.net.Server.Connection instead.
>   - The API user supplies the read buffer when initializing the
>     http.Server, and it is used for the HTTP head as well as a buffer
>     for reading the body into.
> * Replace and document the State enum. No longer is there both "start"
>   and "first".