### PR TITLE
Use content-type header if present to detect format

### DIFF
--- a/src/jetzig/http/Request.zig
+++ b/src/jetzig/http/Request.zig
@@ -151,7 +151,10 @@ pub fn render(self: *Self, status_code: jetzig.http.status_codes.StatusCode) jet
 }
 
 pub fn requestFormat(self: *Self) jetzig.http.Request.Format {
-    return self.extensionFormat() orelse self.acceptHeaderFormat() orelse .UNKNOWN;
+    return self.extensionFormat() orelse
+        self.acceptHeaderFormat() orelse
+        self.contentTypeHeaderFormat() orelse
+        .UNKNOWN;
 }
 
 pub fn getHeader(self: *Self, key: []const u8) ?[]const u8 {
@@ -224,6 +227,17 @@ fn extensionFormat(self: *Self) ?jetzig.http.Request.Format {
 
 pub fn acceptHeaderFormat(self: *Self) ?jetzig.http.Request.Format {
     const acceptHeader = self.getHeader("Accept");
+
+    if (acceptHeader) |item| {
+        if (std.mem.eql(u8, item, "text/html")) return .HTML;
+        if (std.mem.eql(u8, item, "application/json")) return .JSON;
+    }
+
+    return null;
+}
+
+pub fn contentTypeHeaderFormat(self: *Self) ?jetzig.http.Request.Format {
+    const acceptHeader = self.getHeader("content-type");
 
     if (acceptHeader) |item| {
         if (std.mem.eql(u8, item, "text/html")) return .HTML;


### PR DESCRIPTION
Detect request format (HTML or JSON) from `content-type` header.

Previous:
- path extension (.json, .html)
- "Accept" header
- default (.UNKNOWN => .HTML)

Current:
- path extension (.json, .html)
- "Accept" header
- "Content-Type" header
- default (.UNKNOWN => .HTML)

Adjust `http.Headers` to do case-insensitive matching to conform to HTTP spec: https://www.rfc-editor.org/rfc/rfc9110.html#name-field-names