### PR TITLE
Allow importing .zig files from src/ in views

### DIFF
--- a/demo/src/app/lib/example.zig
+++ b/demo/src/app/lib/example.zig
@@ -1,3 +1,3 @@
-pub fn exampleFunction() []const u8 {
-    return "example value";
+pub fn exampleFunction(a: i64, b: i64, c: i64) i64 {
+    return a * b * c;
 }

--- a/demo/src/app/views/root.zig
+++ b/demo/src/app/views/root.zig
@@ -1,9 +1,12 @@
 const jetzig = @import("jetzig");
 
+const importedFunction = @import("../lib/example.zig").exampleFunction;
+
 pub fn index(request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
     var root = try data.object();
     try root.put("message", data.string("Welcome to Jetzig!"));
-    try root.put("number", data.integer(customFunction(100, 200, 300)));
+    try root.put("custom_number", data.integer(customFunction(100, 200, 300)));
+    try root.put("imported_number", data.integer(importedFunction(100, 200, 300)));
 
     try request.response.headers.append("x-example-header", "example header value");
 

--- a/demo/src/app/views/static.zig
+++ b/demo/src/app/views/static.zig
@@ -48,6 +48,7 @@ pub fn index(request: *jetzig.StaticRequest, data: *jetzig.Data) !jetzig.View {
     const params = try request.params();
 
     if (params.get("foo")) |foo| try root.put("foo", foo);
+    if (params.get("bar")) |foo| try root.put("bar", foo);
 
     return request.render(.ok);
 }

--- a/src/jetzig.zig
+++ b/src/jetzig.zig
@@ -185,7 +185,3 @@ pub fn base64Decode(allocator: std.mem.Allocator, string: []const u8) ![]const u
     try decoder.decode(ptr, string);
     return ptr;
 }
-
-test {
-    @import("std").testing.refAllDecls(@This());
-}

--- a/src/jetzig/http/Server.zig
+++ b/src/jetzig/http/Server.zig
@@ -331,6 +331,8 @@ fn matchRoute(self: *Self, request: *jetzig.http.Request, static: bool) !?*jetzi
 const StaticResource = struct { content: []const u8, mime_type: []const u8 = "application/octet-stream" };
 
 fn matchStaticResource(self: *Self, request: *jetzig.http.Request) !?StaticResource {
+    // TODO: Map public and static routes at launch to avoid accessing the file system when
+    // matching any route - currently every request causes file system traversal.
     const public_resource = try self.matchPublicContent(request);
     if (public_resource) |resource| return resource;
 
@@ -458,7 +460,7 @@ fn staticPath(request: *jetzig.http.Request, route: jetzig.views.Route) !?[]cons
         .index, .post => return try std.mem.concat(
             request.allocator,
             u8,
-            &[_][]const u8{ route.name, "_", extension },
+            &[_][]const u8{ route.name, extension },
         ),
         else => return null,
     }


### PR DESCRIPTION
Views are copied to zig-cache, meaning that any files in `src/` are not available for `@import` by default. Copy all .zig files from `src/` into zig-cache so that relative imports work as expected. This also removes the need to specifically copy views into zig-cache as the full tree is now present.

Also fix a bug in static route fallback - remove superfluous underscore so static routes with non-matching params render default HTML/JSON content.