### PR TITLE
Remove unneeded filesystem lookup

### DIFF
--- a/src/jetzig.zig
+++ b/src/jetzig.zig
@@ -53,16 +53,6 @@ pub fn init(allocator: std.mem.Allocator) !App {
         true => caches.Cache{ .memory_cache = caches.MemoryCache.init(allocator) },
         false => caches.Cache{ .null_cache = caches.NullCache.init(allocator) },
     };
-    const root_path = std.fs.cwd().realpathAlloc(allocator, "src/app") catch |err| {
-        switch (err) {
-            error.FileNotFound => {
-                std.debug.print("Unable to find base directory: ./app\nExiting.\n", .{});
-                std.os.exit(1);
-            },
-            else => return err,
-        }
-    };
-
     var logger = loggers.Logger{ .development_logger = loggers.DevelopmentLogger.init(allocator) };
     const secret = try generateSecret(allocator);
     logger.debug(
@@ -73,7 +63,6 @@ pub fn init(allocator: std.mem.Allocator) !App {
     const server_options = http.Server.ServerOptions{
         .cache = server_cache,
         .logger = logger,
-        .root_path = root_path,
         .secret = secret,
     };
 
@@ -82,7 +71,6 @@ pub fn init(allocator: std.mem.Allocator) !App {
         .allocator = allocator,
         .host = host,
         .port = port,
-        .root_path = root_path,
     };
 }
 

--- a/src/jetzig/App.zig
+++ b/src/jetzig/App.zig
@@ -9,7 +9,6 @@ server_options: jetzig.http.Server.ServerOptions,
 allocator: std.mem.Allocator,
 host: []const u8,
 port: u16,
-root_path: []const u8,
 
 pub fn deinit(self: Self) void {
     _ = self;
@@ -59,7 +58,6 @@ pub fn start(self: Self, comptime_routes: []jetzig.views.Route) !void {
     );
 
     defer server.deinit();
-    defer self.allocator.free(self.root_path);
     defer self.allocator.free(self.host);
     defer self.allocator.free(server.options.secret);
 

--- a/src/jetzig/http/Server.zig
+++ b/src/jetzig/http/Server.zig
@@ -13,7 +13,6 @@ else
 pub const ServerOptions = struct {
     cache: jetzig.caches.Cache,
     logger: jetzig.loggers.Logger,
-    root_path: []const u8,
     secret: []const u8,
 };
 


### PR DESCRIPTION
`root_path` is cruft from previous route/template matching mechanism. Caused failure when running binary in isolation: binary can now run independently without any dependency on file system other than:

```
* public/ <-- should always be separate to allow e.g. serving directly
              via nginx
* static/ <-- later will be compiled into binary
```