### PR TITLE
Add .DS_Store to gitignore

### DIFF
--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -2,3 +2,4 @@ zig-cache/
 zig-out/
 static/
 src/app/views/**/.*.zig
+.DS_Store


### PR DESCRIPTION
MacOS generates [.DS_Store](https://superuser.com/a/757596) junk files, and usually this is included in .gitignore in most projects to avoid confusion and polluting the repository. I think this should also be in Jetzig's default .gitignore.

<img src="https://github.com/Avdan-OS/Compositor/assets/51555391/d0379882-f2dc-42e1-962f-b3f122db656f" alt="vibe" width="60"/>