### PR TITLE
Fix CI silent failure bug

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,7 +52,9 @@ jobs:
           for target in "${targets[@]}"; do
             mkdir -p $root/artifacts/$target
             echo "Building target ${target}..."
-            zig build -Dtarget=${target} -Doptimize=ReleaseSafe --prefix $root/artifacts/${target}/ &
+            if ! zig build -Dtarget=${target} -Doptimize=ReleaseSafe --prefix $root/artifacts/${target}/; then
+              exit 1
+            fi
             sed -e '1,5d' < $root/README.md > $root/artifacts/${target}/README.md
             cp $root/LICENSE $root/artifacts/${target}/
           done


### PR DESCRIPTION
CI failed silently during "Build artifacts" stage when build failed in the bash for loop causing the overall job to be successful even when it wasn't.