### PR TITLE
Closes #53: Add support for empty HTTP query param

### DIFF
--- a/demo/src/app/views/redirect.zig
+++ b/demo/src/app/views/redirect.zig
@@ -5,7 +5,15 @@ pub fn index(request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
     _ = data;
     const params = try request.params();
     if (params.get("redirect")) |location| {
-        return request.redirect(try location.toString(), .moved_permanently);
+        switch (location.*) {
+            // Value is `.Null` when param is empty, e.g.:
+            // `http://localhost:8080/redirect?redirect`
+            .Null => return request.redirect("http://www.example.com/", .moved_permanently),
+            // Value is `.string` when param is present, e.g.:
+            // `http://localhost:8080/redirect?redirect=https://jetzig.dev/`
+            .string => |string| return request.redirect(string.value, .moved_permanently),
+            else => unreachable,
+        }
     }
 
     return request.render(.ok);

--- a/src/jetzig/http/Server.zig
+++ b/src/jetzig/http/Server.zig
@@ -146,6 +146,7 @@ fn renderHTML(
     if (route) |matched_route| {
         const template = zmpl.find(matched_route.template);
         if (template == null) {
+            request.response_data.noop(bool, false); // FIXME: Weird Zig bug ? Any call here fixes it.
             if (try self.renderMarkdown(request, route)) |rendered_markdown| {
                 return request.setResponse(rendered_markdown, .{});
             }
@@ -376,7 +377,7 @@ fn renderNotFound(request: *jetzig.http.Request) !RenderedView {
 fn renderBadRequest(request: *jetzig.http.Request) !RenderedView {
     request.response_data.reset();
 
-    const status: jetzig.http.StatusCode = .not_found;
+    const status: jetzig.http.StatusCode = .bad_request;
     const content = try request.formatStatus(status);
     return .{
         .view = jetzig.views.View{ .data = request.response_data, .status_code = status },


### PR DESCRIPTION
When query param is empty, use `jetzig.data.Data.NullType` - this way the value is still non-null (i.e. can be captured) and is still a `jetzig.data.Value` so is consistent with previous implementation.

Add very weird bugfix for 404 responses.

Fix `Bad Request` response code.