### PR TITLE
Background jobs

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -14,6 +14,10 @@
             .url = "https://github.com/MasterQ32/zig-args/archive/01d72b9a0128c474aeeb9019edd48605fa6d95f7.tar.gz",
             .hash = "12208a1de366740d11de525db7289345949f5fd46527db3f89eecc7bb49b012c0732",
         },
+        .jetkv = .{
+            .url = "https://github.com/jetzig-framework/jetkv/archive/a6fcc2df220c1a40094e167eeb567bb5888404e9.tar.gz",
+            .hash = "12207bd2d7465b33e745a5b0567172377f94a221d1fc9aab238bb1b372c64f4ec1a0",
+        },
     },
 
     .paths = .{

--- a/cli/commands/generate/job.zig
+++ b/cli/commands/generate/job.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+
+/// Run the job generator. Create a job in `src/app/jobs/`
+pub fn run(allocator: std.mem.Allocator, cwd: std.fs.Dir, args: [][]const u8, help: bool) !void {
+    if (help or args.len != 1) {
+        std.debug.print(
+            \\Generate a new Job. Jobs can be scheduled to run in the background.
+            \\Use a Job when you need to return a request immediately and perform
+            \\another task asynchronously.
+            \\
+            \\Example:
+            \\
+            \\  jetzig generate job iguana
+            \\
+        , .{});
+
+        if (help) return;
+
+        return error.JetzigCommandError;
+    }
+
+    const dir_path = try std.fs.path.join(allocator, &[_][]const u8{ "src", "app", "jobs" });
+    defer allocator.free(dir_path);
+
+    var dir = try cwd.makeOpenPath(dir_path, .{});
+    defer dir.close();
+
+    const filename = try std.mem.concat(allocator, u8, &[_][]const u8{ args[0], ".zig" });
+    defer allocator.free(filename);
+
+    const file = dir.createFile(filename, .{ .exclusive = true }) catch |err| {
+        switch (err) {
+            error.PathAlreadyExists => {
+                std.debug.print("Partial already exists: {s}\n", .{filename});
+                return error.JetzigCommandError;
+            },
+            else => return err,
+        }
+    };
+
+    try file.writeAll(
+        \\const std = @import("std");
+        \\const jetzig = @import("jetzig");
+        \\
+        \\/// The `run` function for all jobs receives an arena allocator, a logger, and the params
+        \\/// passed to the job when it was created.
+        \\pub fn run(allocator: std.mem.Allocator, params: *jetzig.data.Value, logger: jetzig.Logger) !void {
+        \\    // Job execution code
+        \\}
+        \\
+    );
+
+    file.close();
+
+    const realpath = try dir.realpathAlloc(allocator, filename);
+    defer allocator.free(realpath);
+    std.debug.print("Generated job: {s}\n", .{realpath});
+}

--- a/cli/commands/generate/layout.zig
+++ b/cli/commands/generate/layout.zig
@@ -1,16 +1,21 @@
 const std = @import("std");
 
 /// Run the layout generator. Create a layout template in `src/app/views/layouts`
-pub fn run(allocator: std.mem.Allocator, cwd: std.fs.Dir, args: [][]const u8) !void {
-    if (args.len != 1) {
+pub fn run(allocator: std.mem.Allocator, cwd: std.fs.Dir, args: [][]const u8, help: bool) !void {
+    if (help or args.len != 1) {
         std.debug.print(
-            \\Expected a layout name.
+            \\Generate a layout. Layouts encapsulate common boilerplate mark-up.
+            \\
+            \\Specify a layout name to create a new Zmpl template in src/app/views/layouts/
             \\
             \\Example:
             \\
             \\  jetzig generate layout standard
             \\
         , .{});
+
+        if (help) return;
+
         return error.JetzigCommandError;
     }
 

--- a/cli/commands/generate/middleware.zig
+++ b/cli/commands/generate/middleware.zig
@@ -2,16 +2,19 @@ const std = @import("std");
 const util = @import("../../util.zig");
 
 /// Run the middleware generator. Create a middleware file in `src/app/middleware/`
-pub fn run(allocator: std.mem.Allocator, cwd: std.fs.Dir, args: [][]const u8) !void {
-    if (args.len != 1 or !util.isCamelCase(args[0])) {
+pub fn run(allocator: std.mem.Allocator, cwd: std.fs.Dir, args: [][]const u8, help: bool) !void {
+    if (help or args.len != 1 or !util.isCamelCase(args[0])) {
         std.debug.print(
-            \\Expected a middleware name in CamelCase.
+            \\Generate a middleware module. Module name must be in CamelCase.
             \\
             \\Example:
             \\
             \\  jetzig generate middleware IguanaBrain
             \\
         , .{});
+
+        if (help) return;
+
         return error.JetzigCommandError;
     }
 

--- a/cli/commands/generate/partial.zig
+++ b/cli/commands/generate/partial.zig
@@ -1,16 +1,19 @@
 const std = @import("std");
 
 /// Run the partial generator. Create a partial template in `src/app/views/`
-pub fn run(allocator: std.mem.Allocator, cwd: std.fs.Dir, args: [][]const u8) !void {
-    if (args.len != 2) {
+pub fn run(allocator: std.mem.Allocator, cwd: std.fs.Dir, args: [][]const u8, help: bool) !void {
+    if (help or args.len != 2) {
         std.debug.print(
-            \\Expected a view name and a name for a partial.
+            \\Generate a partial template. Expects a view name followed by a partial name.
             \\
             \\Example:
             \\
             \\  jetzig generate partial iguanas ziglet
             \\
         , .{});
+
+        if (help) return;
+
         return error.JetzigCommandError;
     }
 

--- a/cli/commands/generate/secret.zig
+++ b/cli/commands/generate/secret.zig
@@ -1,7 +1,15 @@
 const std = @import("std");
 
 /// Generate a secure random secret and output to stdout.
-pub fn run(allocator: std.mem.Allocator, cwd: std.fs.Dir, args: [][]const u8) !void {
+pub fn run(allocator: std.mem.Allocator, cwd: std.fs.Dir, args: [][]const u8, help: bool) !void {
+    if (help) {
+        std.debug.print(
+            \\Generate a secure random secret suitable for use as the `JETZIG_SECRET` environment variable.
+            \\
+        , .{});
+        return;
+    }
+
     _ = allocator;
     _ = args;
     _ = cwd;

--- a/cli/commands/generate/view.zig
+++ b/cli/commands/generate/view.zig
@@ -2,17 +2,27 @@ const std = @import("std");
 const util = @import("../../util.zig");
 
 /// Run the view generator. Create a view in `src/app/views/`
-pub fn run(allocator: std.mem.Allocator, cwd: std.fs.Dir, args: [][]const u8) !void {
-    if (args.len == 0) {
-        std.debug.print(".\n", .{});
+pub fn run(allocator: std.mem.Allocator, cwd: std.fs.Dir, args: [][]const u8, help: bool) !void {
+    if (help or args.len == 0) {
         std.debug.print(
-            \\Expected view name followed by optional actions.
+            \\Generate a view. Pass optional action names from:
+            \\  index, get, post, put, patch, delete
+            \\
+            \\Optionally suffix actions with `:static` to use static routing.
+            \\Static requests are rendered at build time only. Use static routes
+            \\when rendering takes a long time and content does not change between
+            \\deployments.
+            \\
+            \\Omit action names to generate a view with all actions defined.
             \\
             \\Example:
             \\
             \\  jetzig generate view iguanas index:static get post delete
             \\
         , .{});
+
+        if (help) return;
+
         return error.JetzigCommandError;
     }
 

--- a/demo/src/app/jobs/example.zig
+++ b/demo/src/app/jobs/example.zig
@@ -1,0 +1,9 @@
+const std = @import("std");
+const jetzig = @import("jetzig");
+
+/// The `run` function for all jobs receives an arena allocator, a logger, and the params
+/// passed to the job when it was created.
+pub fn run(allocator: std.mem.Allocator, params: *jetzig.data.Value, logger: jetzig.Logger) !void {
+    _ = allocator;
+    try logger.INFO("Job received params: {s}", .{try params.toJson()});
+}

--- a/demo/src/app/jobs/iguana.zig
+++ b/demo/src/app/jobs/iguana.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+const jetzig = @import("jetzig");
+
+/// The `run` function for all jobs receives an arena allocator, a logger, and the params
+/// passed to the job when it was created.
+pub fn run(allocator: std.mem.Allocator, params: *jetzig.data.Value, logger: jetzig.Logger) !void {
+    // Job execution code
+}

--- a/demo/src/app/views/background_jobs.zig
+++ b/demo/src/app/views/background_jobs.zig
@@ -1,0 +1,21 @@
+const std = @import("std");
+const jetzig = @import("jetzig");
+
+/// This example demonstrates usage of Jetzig's background jobs.
+pub fn index(request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+
+    // Create a new job using `src/app/jobs/example_job.zig`.
+    var job = try request.job("example");
+
+    // Add a param `foo` to the job.
+    try job.put("foo", data.string("bar"));
+    try job.put("id", data.integer(std.crypto.random.int(u32)));
+
+    // Schedule the job for background processing. The job is added to the queue. When the job is
+    // processed a new instance of `example_job` is created and its `run` function is invoked.
+    // All params are added above are available to the job by calling `job.params()` inside the
+    // `run` function.
+    try job.schedule();
+
+    return request.render(.ok);
+}

--- a/demo/src/app/views/kvstore.zig
+++ b/demo/src/app/views/kvstore.zig
@@ -1,0 +1,35 @@
+const jetzig = @import("jetzig");
+
+/// This example demonstrates usage of Jetzig's KV store.
+pub fn index(request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    var root = try data.object();
+
+    // Fetch a string from the KV store. If it exists, store it in the root data object,
+    // otherwise store a string value to be picked up by the next request.
+    if (request.kvGet(.string, "example-key")) |capture| {
+        try root.put("stored_string", data.string(capture));
+    } else {
+        try request.kvPut(.string, "example-key", "example-value");
+    }
+
+    // Pop an item from the array and store it in the root data object. This will empty the
+    // array after multiple requests.
+    if (request.kvPop("example-array")) |string| try root.put("popped", data.string(string));
+
+    // Fetch an array from the KV store. If it exists, store its values in the root data object,
+    // otherwise store a new array to be picked up by the next request.
+    if (request.kvGet(.array, "example-array")) |kv_array| {
+        var array = try data.array();
+        for (kv_array.items()) |item| try array.append(data.string(item));
+        try root.put("stored_array", array);
+    } else {
+        // Create a KV Array and store it in the key value store.
+        var kv_array = request.kvArray();
+        try kv_array.append("hello");
+        try kv_array.append("goodbye");
+        try kv_array.append("hello again");
+        try request.kvPut(.array, "example-array", kv_array);
+    }
+
+    return request.render(.ok);
+}

--- a/demo/src/main.zig
+++ b/demo/src/main.zig
@@ -32,6 +32,14 @@ pub const jetzig_options = struct {
     // HTTP buffer. Must be large enough to store all headers. This should typically not be modified.
     // pub const http_buffer_size: usize = std.math.pow(usize, 2, 16);
 
+    // The number of worker threads to spawn on startup for processing Jobs (NOT the number of
+    // HTTP server worker threads).
+    pub const job_worker_threads: usize = 4;
+
+    // Duration before looking for more Jobs when the queue is found to be empty, in
+    // milliseconds.
+    // pub const job_worker_sleep_interval_ms: usize = 10;
+
     // Set custom fragments for rendering markdown templates. Any values will fall back to
     // defaults provided by Zmd (https://github.com/bobf/zmd/blob/main/src/zmd/html.zig).
     pub const markdown_fragments = struct {

--- a/src/jetzig.zig
+++ b/src/jetzig.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 pub const zmpl = @import("zmpl").zmpl;
 pub const zmd = @import("zmd").zmd;
+pub const jetkv = @import("jetkv");
 
 pub const http = @import("jetzig/http.zig");
 pub const loggers = @import("jetzig/loggers.zig");
@@ -12,6 +13,7 @@ pub const middleware = @import("jetzig/middleware.zig");
 pub const util = @import("jetzig/util.zig");
 pub const types = @import("jetzig/types.zig");
 pub const markdown = @import("jetzig/markdown.zig");
+pub const jobs = @import("jetzig/jobs.zig");
 
 /// The primary interface for a Jetzig application. Create an `App` in your application's
 /// `src/main.zig` and call `start` to launch the application.
@@ -37,7 +39,22 @@ pub const Data = data.Data;
 /// generate a `View`.
 pub const View = views.View;
 
+/// A route definition. Generated at build type by `Routes.zig`.
+pub const Route = views.Route;
+
 const root = @import("root");
+
+/// An asynchronous job that runs outside of the request/response flow. Create via `Request.job`
+/// and set params with `Job.put`, then call `Job.schedule()` to add to the
+/// job queue.
+pub const Job = jobs.Job;
+
+/// A container for a job definition, includes the job name and run function.
+pub const JobDefinition = jobs.Job.JobDefinition;
+
+/// A generic logger type. Provides all standard log levels as functions (`INFO`, `WARN`,
+/// `ERROR`, etc.). Note that all log functions are CAPITALIZED.
+pub const Logger = loggers.Logger;
 
 /// Global configuration. Override these values by defining in `src/main.zig` with:
 /// ```zig
@@ -69,6 +86,14 @@ pub const config = struct {
 
     /// A struct of fragments to use when rendering Markdown templates.
     pub const markdown_fragments = zmd.html.DefaultFragments;
+
+    /// The number of worker threads to spawn on startup for processing Jobs (NOT the number of
+    /// HTTP server worker threads).
+    pub const job_worker_threads: usize = 1;
+
+    /// Duration before looking for more Jobs when the queue is found to be empty, in
+    /// milliseconds.
+    pub const job_worker_sleep_interval_ms: usize = 10;
 
     /// Reconciles a configuration value from user-defined values and defaults provided by Jetzig.
     pub fn get(T: type, comptime key: []const u8) T {

--- a/src/jetzig/jobs.zig
+++ b/src/jetzig/jobs.zig
@@ -1,0 +1,4 @@
+pub const Job = @import("jobs/Job.zig");
+pub const JobDefinition = Job.JobDefinition;
+pub const Pool = @import("jobs/Pool.zig");
+pub const Worker = @import("jobs/Worker.zig");

--- a/src/jetzig/jobs/Job.zig
+++ b/src/jetzig/jobs/Job.zig
@@ -1,0 +1,78 @@
+const std = @import("std");
+const jetzig = @import("../../jetzig.zig");
+
+/// Job name and run function, used when generating an array of job definitions at build time.
+pub const JobDefinition = struct {
+    name: []const u8,
+    runFn: *const fn (std.mem.Allocator, *jetzig.data.Value, jetzig.loggers.Logger) anyerror!void,
+};
+
+allocator: std.mem.Allocator,
+jet_kv: *jetzig.jetkv.JetKV,
+logger: jetzig.loggers.Logger,
+name: []const u8,
+definition: ?JobDefinition,
+data: ?*jetzig.data.Data = null,
+_params: ?*jetzig.data.Value = null,
+
+const Job = @This();
+
+/// Initialize a new Job
+pub fn init(
+    allocator: std.mem.Allocator,
+    jet_kv: *jetzig.jetkv.JetKV,
+    logger: jetzig.loggers.Logger,
+    jobs: []const JobDefinition,
+    name: []const u8,
+) Job {
+    var definition: ?JobDefinition = null;
+
+    for (jobs) |job_definition| {
+        if (std.mem.eql(u8, job_definition.name, name)) {
+            definition = job_definition;
+            break;
+        }
+    }
+
+    return .{
+        .allocator = allocator,
+        .jet_kv = jet_kv,
+        .logger = logger,
+        .name = name,
+        .definition = definition,
+    };
+}
+
+/// Deinitialize the Job and frees memory
+pub fn deinit(self: *Job) void {
+    if (self.data) |data| {
+        data.deinit();
+        self.allocator.destroy(data);
+    }
+}
+
+/// Add a parameter to the Job
+pub fn put(self: *Job, key: []const u8, value: *jetzig.data.Value) !void {
+    var job_params = try self.params();
+    try job_params.put(key, value);
+}
+
+/// Add a Job to the queue
+pub fn schedule(self: *Job) !void {
+    _ = try self.params();
+    const json = try self.data.?.toJson();
+    try self.jet_kv.prepend("__jetzig_jobs", json);
+    try self.logger.INFO("Scheduled job: {s}", .{self.name});
+}
+
+fn params(self: *Job) !*jetzig.data.Value {
+    if (self.data == null) {
+        self.data = try self.allocator.create(jetzig.data.Data);
+        self.data.?.* = jetzig.data.Data.init(self.allocator);
+        self._params = try self.data.?.object();
+        try self._params.?.put("__jetzig_job_name", self.data.?.string(self.name));
+    }
+    return self._params.?;
+}
+
+// TODO: Tests :)

--- a/src/jetzig/jobs/Pool.zig
+++ b/src/jetzig/jobs/Pool.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+
+const jetzig = @import("../../jetzig.zig");
+
+const Pool = @This();
+
+allocator: std.mem.Allocator,
+jet_kv: *jetzig.jetkv.JetKV,
+job_definitions: []const jetzig.jobs.JobDefinition,
+logger: jetzig.loggers.Logger,
+pool: std.Thread.Pool = undefined,
+workers: std.ArrayList(*jetzig.jobs.Worker),
+
+/// Initialize a new worker thread pool.
+pub fn init(
+    allocator: std.mem.Allocator,
+    jet_kv: *jetzig.jetkv.JetKV,
+    job_definitions: []const jetzig.jobs.JobDefinition,
+    logger: jetzig.loggers.Logger,
+) Pool {
+    return .{
+        .allocator = allocator,
+        .jet_kv = jet_kv,
+        .job_definitions = job_definitions,
+        .logger = logger,
+        .workers = std.ArrayList(*jetzig.jobs.Worker).init(allocator),
+    };
+}
+
+/// Free pool resources and destroy workers.
+pub fn deinit(self: *Pool) void {
+    self.pool.deinit();
+    for (self.workers.items) |worker| self.allocator.destroy(worker);
+    self.workers.deinit();
+}
+
+/// Spawn a given number of threads and start processing jobs, sleep for a given interval (ms)
+/// when no jobs are in the queue. Each worker operates its own work loop.
+pub fn work(self: *Pool, threads: usize, interval: usize) !void {
+    try self.pool.init(.{ .allocator = self.allocator });
+
+    for (0..threads) |index| {
+        const worker = try self.allocator.create(jetzig.jobs.Worker);
+        worker.* = jetzig.jobs.Worker.init(
+            self.allocator,
+            self.logger,
+            index,
+            self.jet_kv,
+            self.job_definitions,
+            interval,
+        );
+        try self.workers.append(worker);
+        try self.pool.spawn(jetzig.jobs.Worker.work, .{worker});
+    }
+}

--- a/src/jetzig/jobs/Worker.zig
+++ b/src/jetzig/jobs/Worker.zig
@@ -1,0 +1,123 @@
+const std = @import("std");
+
+const jetzig = @import("../../jetzig.zig");
+const Worker = @This();
+
+allocator: std.mem.Allocator,
+logger: jetzig.loggers.Logger,
+id: usize,
+jet_kv: *jetzig.jetkv.JetKV,
+job_definitions: []const jetzig.jobs.JobDefinition,
+interval: usize,
+
+pub fn init(
+    allocator: std.mem.Allocator,
+    logger: jetzig.loggers.Logger,
+    id: usize,
+    jet_kv: *jetzig.jetkv.JetKV,
+    job_definitions: []const jetzig.jobs.JobDefinition,
+    interval: usize,
+) Worker {
+    return .{
+        .allocator = allocator,
+        .logger = logger,
+        .id = id,
+        .jet_kv = jet_kv,
+        .job_definitions = job_definitions,
+        .interval = interval * 1000 * 1000, // millisecond => nanosecond
+    };
+}
+
+/// Begin working through jobs in the queue.
+pub fn work(self: *const Worker) void {
+    self.log(.INFO, "[worker-{}] Job worker started.", .{self.id});
+
+    while (true) {
+        if (self.jet_kv.pop("__jetzig_jobs")) |json| {
+            defer self.allocator.free(json);
+            if (self.matchJob(json)) |job_definition| {
+                self.processJob(job_definition, json);
+            }
+        } else {
+            std.time.sleep(self.interval);
+        }
+    }
+
+    self.log(.INFO, "[worker-{}] Job worker exited.", .{self.id});
+}
+
+// Do a minimal parse of JSON job data to identify job name, then match on known job definitions.
+fn matchJob(self: Worker, json: []const u8) ?jetzig.jobs.JobDefinition {
+    const parsed_json = std.json.parseFromSlice(
+        struct { __jetzig_job_name: []const u8 },
+        self.allocator,
+        json,
+        .{ .ignore_unknown_fields = true },
+    ) catch |err| {
+        self.log(
+            .ERROR,
+            "[worker-{}] Error parsing JSON from job queue: {s}",
+            .{ self.id, @errorName(err) },
+        );
+        return null;
+    };
+
+    const job_name = parsed_json.value.__jetzig_job_name;
+
+    // TODO: Hashmap
+    for (self.job_definitions) |job_definition| {
+        if (std.mem.eql(u8, job_definition.name, job_name)) {
+            parsed_json.deinit();
+            return job_definition;
+        }
+    } else {
+        self.log(.WARN, "[worker-{}] Tried to process unknown job: {s}", .{ self.id, job_name });
+        return null;
+    }
+}
+
+// Fully parse JSON job data and invoke the defined job's run function, passing the parsed params
+// as a `*jetzig.data.Value`.
+fn processJob(self: Worker, job_definition: jetzig.JobDefinition, json: []const u8) void {
+    var data = jetzig.data.Data.init(self.allocator);
+    defer data.deinit();
+
+    data.fromJson(json) catch |err| {
+        self.log(
+            .INFO,
+            "[worker-{}] Error parsing JSON for job `{s}`: {s}",
+            .{ self.id, job_definition.name, @errorName(err) },
+        );
+    };
+
+    var arena = std.heap.ArenaAllocator.init(self.allocator);
+    defer arena.deinit();
+
+    if (data.value) |params| {
+        job_definition.runFn(arena.allocator(), params, self.logger) catch |err| {
+            self.log(
+                .ERROR,
+                "[worker-{}] Encountered error processing job `{s}`: {s}",
+                .{ self.id, job_definition.name, @errorName(err) },
+            );
+            return;
+        };
+        self.log(.INFO, "[worker-{}] Job completed: {s}", .{ self.id, job_definition.name });
+    } else {
+        self.log(.ERROR, "Error in job params definition for job: {s}", .{job_definition.name});
+    }
+}
+
+// Log with error handling and fallback. Prefix with worker ID.
+fn log(
+    self: Worker,
+    comptime level: jetzig.loggers.LogLevel,
+    comptime message: []const u8,
+    args: anytype,
+) void {
+    self.logger.log(level, message, args) catch |err| {
+        // XXX: In (daemonized) deployment stderr will not be available, find a better solution.
+        // Note that this only occurs if logging itself fails.
+        std.debug.print("[worker-{}] Logger encountered error: {s}\n", .{ self.id, @errorName(err) });
+    };
+}

--- a/src/jetzig/loggers.zig
+++ b/src/jetzig/loggers.zig
@@ -61,4 +61,15 @@ pub const Logger = union(enum) {
             inline else => |*logger| try logger.logRequest(request),
         }
     }
+
+    pub fn log(
+        self: *const Logger,
+        comptime level: LogLevel,
+        comptime message: []const u8,
+        args: anytype,
+    ) !void {
+        switch (self.*) {
+            inline else => |*logger| try logger.log(level, message, args),
+        }
+    }
 };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3,5 +3,5 @@ test {
     _ = @import("jetzig/http/Headers.zig");
     _ = @import("jetzig/http/Cookies.zig");
     _ = @import("jetzig/http/Path.zig");
-    @import("std").testing.refAllDeclsRecursive(@This());
+    _ = @import("jetzig/jobs/Job.zig");
 }


### PR DESCRIPTION
Use in-memory KV store (JetKV) for simple job queue.

Build script generates an array of Zig modules in `src/app/jobs/` and stores their name + run function (`run(allocator, params, logger)`).

View functions schedule jobs with arbitrary params.

Thread pool spawns a (configurable) number of workers and pops jobs from the queue, then invokes the appropriate run function.