### PR TITLE
Update Zmpl, adds Markdown mode formatters

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -173,7 +173,7 @@ pub fn jetzigInit(b: *std.Build, exe: *std.Build.Step.Compile, options: JetzigIn
             if (!std.mem.eql(u8, ".zig", std.fs.path.extension(entry.path))) continue;
 
             const stat = try src_dir.statFile(entry.path);
-            const src_data = try src_dir.readFileAlloc(b.allocator, entry.path, stat.size);
+            const src_data = try src_dir.readFileAlloc(b.allocator, entry.path, @intCast(stat.size));
             defer b.allocator.free(src_data);
 
             const relpath = try std.fs.path.join(b.allocator, &[_][]const u8{ "src", entry.path });
@@ -216,7 +216,7 @@ fn generateMarkdownFragments(b: *std.Build) ![]const u8 {
         }
     };
     const stat = try file.stat();
-    const source = try file.readToEndAllocOptions(b.allocator, stat.size, null, @alignOf(u8), 0);
+    const source = try file.readToEndAllocOptions(b.allocator, @intCast(stat.size), null, @alignOf(u8), 0);
     if (try getMarkdownFragmentsSource(b.allocator, source)) |markdown_fragments_source| {
         return try std.fmt.allocPrint(b.allocator,
             \\const std = @import("std");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,12 +3,12 @@
     .version = "0.0.0",
     .dependencies = .{
         .zmd = .{
-            .url = "https://github.com/jetzig-framework/zmd/archive/45a9ff0e3a55b4758163abad5a601bd3ef8127a8.tar.gz",
-            .hash = "122067a3107499e4b561a883a9f1e9f39662c4b87249a2e4e630279bd91ab7840230",
+            .url = "https://github.com/jetzig-framework/zmd/archive/557ab8a29c0f7b5d096070cde2858cf27da8b0f1.tar.gz",
+            .hash = "1220482f07f2bbaef335f20d6890c15a1e14739950b784232bc69182423520e058a5",
         },
         .zmpl = .{
-            .url = "https://github.com/jetzig-framework/zmpl/archive/9712b85e61f33879f388d5e1829856e326c53822.tar.gz",
-            .hash = "1220b185cf8316ae5ad6dd7d45bea278575391986b7d8233a9d9b2c342e339d65ac0",
+            .url = "https://github.com/jetzig-framework/zmpl/archive/046c05d376a4fe89d86c52596baa18137891cd87.tar.gz",
+            .hash = "1220d8890b1161e4356d2c59d4b88280566d55480dae840b6f5dae34bf852bef6b56",
         },
         .args = .{
             .url = "https://github.com/MasterQ32/zig-args/archive/01d72b9a0128c474aeeb9019edd48605fa6d95f7.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,12 +3,12 @@
     .version = "0.0.0",
     .dependencies = .{
         .zmd = .{
-            .url = "https://github.com/jetzig-framework/zmd/archive/901e4ce55cdbfd82c42cfd4feb3a1682dab4b418.tar.gz",
-            .hash = "12207d49df326e0c180a90fa65d9993898e0a0ffd8e79616b4b81f81769261858856",
+            .url = "https://github.com/jetzig-framework/zmd/archive/45a9ff0e3a55b4758163abad5a601bd3ef8127a8.tar.gz",
+            .hash = "122067a3107499e4b561a883a9f1e9f39662c4b87249a2e4e630279bd91ab7840230",
         },
         .zmpl = .{
-            .url = "https://github.com/jetzig-framework/zmpl/archive/4511ae706e8679385d38cc1366497082f8f53afb.tar.gz",
-            .hash = "1220d493e6fdfaccbafff41df2b7b407728ed11619bebb198c90dae9420f03a6d29d",
+            .url = "https://github.com/jetzig-framework/zmpl/archive/9712b85e61f33879f388d5e1829856e326c53822.tar.gz",
+            .hash = "1220b185cf8316ae5ad6dd7d45bea278575391986b7d8233a9d9b2c342e339d65ac0",
         },
         .args = .{
             .url = "https://github.com/MasterQ32/zig-args/archive/01d72b9a0128c474aeeb9019edd48605fa6d95f7.tar.gz",

--- a/cli/compile.zig
+++ b/cli/compile.zig
@@ -45,7 +45,7 @@ pub fn initDataModule(build: *std.Build) !*std.Build.Module {
         const stat = try dir.statFile(path);
         const encoded = base64Encode(
             build.allocator,
-            try dir.readFileAlloc(build.allocator, path, stat.size),
+            try dir.readFileAlloc(build.allocator, path, @intCast(stat.size)),
         );
         defer build.allocator.free(encoded);
 

--- a/demo/src/app/views/markdown/index.md.zmpl
+++ b/demo/src/app/views/markdown/index.md.zmpl
@@ -2,11 +2,11 @@
 
 ![jetzig logo](https://www.jetzig.dev/jetzig.png)
 
-_Markdown_ is rendered by _[zmd](https://github.com/jetzig-framework/zmd)_.
+_Markdown_ is rendered by [zmd](https://github.com/jetzig-framework/zmd).
 
 You can use a `StaticRequest` in your view if you prefer to render your _Markdown_ at build time, or use `Request` in development to render at run time without a server restart.
 
-Simply create a `.md` file instead of a `.zmpl` file, e.g. `src/app/views/iguanas/index.md` and _Markdown_ will be rendered.
+Simply create a `.md.zmpl` file instead of a `.zmpl` file, e.g. `src/app/views/iguanas/index.md.zmpl` and _Markdown_ will be rendered. You can still use _Zmpl_ references, modes, and partials. In fact, a `.md.zmpl` template is simply a regular _Zmpl_ template with the root mode set to `markdown`.
 
 ## An _ordered_ list
 

--- a/demo/src/app/views/quotes.zig
+++ b/demo/src/app/views/quotes.zig
@@ -37,7 +37,7 @@ const Quote = struct {
 fn randomQuote(allocator: std.mem.Allocator) !Quote {
     const path = "src/app/config/quotes.json";
     const stat = try std.fs.cwd().statFile(path);
-    const json = try std.fs.cwd().readFileAlloc(allocator, path, stat.size);
+    const json = try std.fs.cwd().readFileAlloc(allocator, path, @intCast(stat.size));
     const quotes = try std.json.parseFromSlice([]Quote, allocator, json, .{});
     return quotes.value[std.crypto.random.intRangeLessThan(usize, 0, quotes.value.len)];
 }

--- a/demo/src/app/views/root/index.zmpl
+++ b/demo/src/app/views/root/index.zmpl
@@ -16,9 +16,3 @@
   <div>Take a look at the <span class="font-mono">/demo/src/app/</span> directory to see how this application works.</div>
   <div>Visit <a class="font-bold text-[#39b54a]" href="https://jetzig.dev/">jetzig.dev</a> to get started.</div>
 </div>
-
-@markdown {
-  # Hello
-
-  [foobar](https://www.google.com)
-}

--- a/demo/src/app/views/root/index.zmpl
+++ b/demo/src/app/views/root/index.zmpl
@@ -16,3 +16,9 @@
   <div>Take a look at the <span class="font-mono">/demo/src/app/</span> directory to see how this application works.</div>
   <div>Visit <a class="font-bold text-[#39b54a]" href="https://jetzig.dev/">jetzig.dev</a> to get started.</div>
 </div>
+
+@markdown {
+  # Hello
+
+  [foobar](https://www.google.com)
+}

--- a/demo/src/main.zig
+++ b/demo/src/main.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
-pub const jetzig = @import("jetzig");
+const jetzig = @import("jetzig");
+const zmd = @import("zmd");
 
 pub const routes = @import("routes");
 
@@ -54,14 +55,14 @@ pub const jetzig_options = struct {
     // pub const force_development_email_delivery = false;
 
     // Set custom fragments for rendering markdown templates. Any values will fall back to
-    // defaults provided by Zmd (https://github.com/bobf/zmd/blob/main/src/zmd/html.zig).
+    // defaults provided by Zmd (https://github.com/jetzig-framework/zmd/blob/main/src/zmd/html.zig).
     pub const markdown_fragments = struct {
         pub const root = .{
             "<div class='p-5'>",
             "</div>",
         };
         pub const h1 = .{
-            "<h1 class='text-2xl mb-3 font-bold'>",
+            "<h1 class='text-2xl mb-3 text-green font-bold'>",
             "</h1>",
         };
         pub const h2 = .{
@@ -91,13 +92,13 @@ pub const jetzig_options = struct {
             "</ul>",
         };
 
-        pub fn block(allocator: std.mem.Allocator, node: jetzig.zmd.Node) ![]const u8 {
+        pub fn block(allocator: std.mem.Allocator, node: zmd.Node) ![]const u8 {
             return try std.fmt.allocPrint(allocator,
                 \\<pre class="w-1/2 font-mono mt-4 ms-3 bg-gray-900 p-2 text-white"><code class="language-{?s}">{s}</code></pre>
             , .{ node.meta, node.content });
         }
 
-        pub fn link(allocator: std.mem.Allocator, node: jetzig.zmd.Node) ![]const u8 {
+        pub fn link(allocator: std.mem.Allocator, node: zmd.Node) ![]const u8 {
             return try std.fmt.allocPrint(allocator,
                 \\<a class="underline decoration-sky-500" href="{0s}" title={1s}>{1s}</a>
             , .{ node.href.?, node.title.? });

--- a/src/GenerateMimeTypes.zig
+++ b/src/GenerateMimeTypes.zig
@@ -10,7 +10,7 @@ const JsonMimeType = struct {
 pub fn generateMimeModule(build: *std.Build) !*std.Build.Module {
     const file = try std.fs.openFileAbsolute(build.pathFromRoot("src/jetzig/http/mime/mimeData.json"), .{});
     const stat = try file.stat();
-    const json = try file.readToEndAlloc(build.allocator, stat.size);
+    const json = try file.readToEndAlloc(build.allocator, @intCast(stat.size));
     defer build.allocator.free(json);
 
     const parsed_mime_types = try std.json.parseFromSlice(

--- a/src/Routes.zig
+++ b/src/Routes.zig
@@ -296,7 +296,7 @@ const RouteSet = struct {
 
 fn generateRoutesForView(self: *Routes, dir: std.fs.Dir, path: []const u8) !RouteSet {
     const stat = try dir.statFile(path);
-    const source = try dir.readFileAllocOptions(self.allocator, path, stat.size, null, @alignOf(u8), 0);
+    const source = try dir.readFileAllocOptions(self.allocator, path, @intCast(stat.size), null, @alignOf(u8), 0);
     defer self.allocator.free(source);
 
     self.ast = try std.zig.Ast.parse(self.allocator, source, .zig);

--- a/src/compile_static_routes.zig
+++ b/src/compile_static_routes.zig
@@ -143,7 +143,7 @@ fn renderZmplTemplate(
             defer allocator.free(prefixed_name);
 
             if (zmpl.findPrefixed("views", prefixed_name)) |layout| {
-                return try template.renderWithLayout(layout, view.data);
+                return try template.renderWithOptions(view.data, .{ .layout = layout });
             } else {
                 std.debug.print("Unknown layout: {s}\n", .{layout_name});
                 return try allocator.dupe(u8, "");

--- a/src/jetzig/markdown.zig
+++ b/src/jetzig/markdown.zig
@@ -33,7 +33,7 @@ pub fn render(
             else => err,
         };
     };
-    const markdown_content = std.fs.cwd().readFileAlloc(allocator, full_path, stat.size) catch |err| {
+    const markdown_content = std.fs.cwd().readFileAlloc(allocator, full_path, @intCast(stat.size)) catch |err| {
         switch (err) {
             error.FileNotFound => return null,
             else => return err,

--- a/src/jetzig/markdown.zig
+++ b/src/jetzig/markdown.zig
@@ -1,8 +1,9 @@
 const std = @import("std");
 
+const Zmd = @import("zmd").Zmd;
+
 const jetzig = @import("../jetzig.zig");
 
-const Zmd = @import("zmd").Zmd;
 pub fn render(
     allocator: std.mem.Allocator,
     path: []const u8,


### PR DESCRIPTION
Also adds support for `.md.zmpl` templates - root node is Markdown.