### PR TITLE
Custom error pages

### DIFF
--- a/demo/public/404.html
+++ b/demo/public/404.html
@@ -1,0 +1,16 @@
+<style>
+div {
+  padding: 15px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -ms-transform: translateX(-50%) translateY(-50%);
+  -webkit-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  text-align: center;
+}
+</style>
+<div>
+  <img src="/jetzig.png">
+  <h1 style="font-size: 10rem; font-family: sans-serif; color: #f7931e">404</h1>
+</div>

--- a/demo/src/app/views/errors.zig
+++ b/demo/src/app/views/errors.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+const jetzig = @import("jetzig");
+
+// Generic handler for all errors.
+// Use `jetzig.http.status_codes.get(request.status_code)` to get a value that provides string
+// versions of the error code and message for use in templates.
+pub fn index(request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    var root = try data.object();
+    var error_info = try data.object();
+
+    const status = jetzig.http.status_codes.get(request.status_code);
+
+    try error_info.put("code", data.string(status.getCode()));
+    try error_info.put("message", data.string(status.getMessage()));
+
+    try root.put("error", error_info);
+
+    // Render with the original error status code, or override if preferred.
+    return request.render(request.status_code);
+}

--- a/demo/src/app/views/errors/index.zmpl
+++ b/demo/src/app/views/errors/index.zmpl
@@ -1,0 +1,17 @@
+<style>
+div {
+  padding: 15px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -ms-transform: translateX(-50%) translateY(-50%);
+  -webkit-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  text-align: center;
+}
+</style>
+<div>
+  <img src="/jetzig.png" />
+  <h1 style="font-size: 6rem; font-family: sans-serif; color: #f7931e">{{.error.code}}</h1>
+  <h1 style="font-size: 4rem; font-family: sans-serif; color: #39b54a">{{.error.message}}</h1>
+</div>

--- a/src/jetzig/http/Headers.zig
+++ b/src/jetzig/http/Headers.zig
@@ -40,7 +40,7 @@ pub fn getAll(self: Headers, name: []const u8) []const []const u8 {
 }
 
 // Deprecated
-pub fn getFirstValue(self: *Headers, name: []const u8) ?[]const u8 {
+pub fn getFirstValue(self: *const Headers, name: []const u8) ?[]const u8 {
     return self.get(name);
 }
 


### PR DESCRIPTION
Render `src/app/views/errors.zig` view (`index` action) when an unexpected error occurs. If the view does not exist, try rendering `public/404.html`, `public/500.html` (etc.), finally falling back to a standard basic HTML/JSON response.