### PR TITLE
Fixed the command: "jetzig generate layout" to the new zmpl syntax

### DIFF
--- a/cli/commands/generate/layout.zig
+++ b/cli/commands/generate/layout.zig
@@ -45,7 +45,7 @@ pub fn run(allocator: std.mem.Allocator, cwd: std.fs.Dir, args: [][]const u8, he
         \\<html>
         \\  <head></head>
         \\  <body>
-        \\    <main>{zmpl.content}</main>
+        \\    <main>{{zmpl.content}}</main>
         \\  </body>
         \\</html>
         \\


### PR DESCRIPTION
Fixed the `jetzig generate layout` command like we talked on [discord](https://discord.com/channels/1203669535488479273/1203669537246019646/1242247382679294012) to be updated with the new zmpl syntax