### PR TITLE
Implement custom routes

### DIFF
--- a/demo/src/app/views/custom/foo.zig
+++ b/demo/src/app/views/custom/foo.zig
@@ -1,0 +1,7 @@
+const jetzig = @import("jetzig");
+
+pub fn bar(id: []const u8, request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    var root = try data.object();
+    try root.put("id", data.string(id));
+    return request.render(.ok);
+}

--- a/demo/src/app/views/custom/foo/bar.zmpl
+++ b/demo/src/app/views/custom/foo/bar.zmpl
@@ -1,0 +1,3 @@
+{{jetzig_view}}
+{{jetzig_action}}
+{{.id}}

--- a/demo/src/main.zig
+++ b/demo/src/main.zig
@@ -169,5 +169,8 @@ pub fn main() !void {
     const app = try jetzig.init(allocator);
     defer app.deinit();
 
+    // Example custom route:
+    // app.route(.GET, "/custom/:id/foo/bar", @import("app/views/custom/foo.zig"), .bar);
+
     try app.start(routes, .{});
 }

--- a/src/jetzig.zig
+++ b/src/jetzig.zig
@@ -191,5 +191,6 @@ pub fn init(allocator: std.mem.Allocator) !App {
     return .{
         .environment = environment,
         .allocator = allocator,
+        .custom_routes = std.ArrayList(views.Route).init(allocator),
     };
 }

--- a/src/jetzig/http/Path.zig
+++ b/src/jetzig/http/Path.zig
@@ -7,6 +7,7 @@
 /// * Extension (".json", ".html", etc.)
 /// * Query (everything after first "?" character)
 const std = @import("std");
+const jetzig = @import("../../jetzig.zig");
 
 path: []const u8,
 base_path: []const u8,
@@ -36,6 +37,21 @@ pub fn init(path: []const u8) Self {
 /// No-op - no allocations currently performed.
 pub fn deinit(self: *Self) void {
     _ = self;
+}
+
+/// For a given route with a possible `:id` placeholder, return the matching URL segment for that
+/// placeholder. e.g. route with path `/foo/:id/bar` and request path `/foo/1234/bar` returns
+/// `"1234"`.
+pub fn resourceId(self: Self, route: jetzig.views.Route) []const u8 {
+    var route_uri_path_it = std.mem.splitScalar(u8, route.uri_path, '/');
+    var base_path_it = std.mem.splitScalar(u8, self.base_path, '/');
+
+    while (route_uri_path_it.next()) |route_uri_path_segment| {
+        const base_path_segment = base_path_it.next() orelse return self.resource_id;
+        if (std.mem.startsWith(u8, route_uri_path_segment, ":")) return base_path_segment;
+    }
+
+    return self.resource_id;
 }
 
 // Extract `"/foo/bar/baz"` from:

--- a/src/jetzig/http/Request.zig
+++ b/src/jetzig/http/Request.zig
@@ -241,7 +241,7 @@ pub fn setLayout(self: *Request, layout: ?[]const u8) void {
 
 /// Derive a layout name from the current request if defined, otherwise from the route (if
 /// defined).
-pub fn getLayout(self: *Request, route: *jetzig.views.Route) ?[]const u8 {
+pub fn getLayout(self: *Request, route: jetzig.views.Route) ?[]const u8 {
     if (self.layout_disabled) return null;
     if (self.layout) |capture| return capture;
     if (route.layout) |capture| return capture;

--- a/src/jetzig/views.zig
+++ b/src/jetzig/views.zig
@@ -1,2 +1,3 @@
 pub const Route = @import("views/Route.zig");
 pub const View = @import("views/View.zig");
+pub const CustomRoute = @import("views/CustomRoute.zig");

--- a/src/jetzig/views/CustomRoute.zig
+++ b/src/jetzig/views/CustomRoute.zig
@@ -1,0 +1,8 @@
+const jetzig = @import("../../jetzig.zig");
+
+method: jetzig.http.Request.Method,
+path: []const u8,
+view: union(enum) {
+    with_id: *const fn (id: []const u8, *jetzig.http.Request, *jetzig.data.Data) anyerror!jetzig.views.View,
+    without_id: *const fn (*jetzig.http.Request, *jetzig.data.Data) anyerror!jetzig.views.View,
+},

--- a/src/jetzig/views/Route.zig
+++ b/src/jetzig/views/Route.zig
@@ -4,12 +4,12 @@ const jetzig = @import("../../jetzig.zig");
 
 const Route = @This();
 
-pub const Action = enum { index, get, post, put, patch, delete };
+pub const Action = enum { index, get, post, put, patch, delete, custom };
 pub const RenderFn = *const fn (Route, *jetzig.http.Request) anyerror!jetzig.views.View;
 pub const RenderStaticFn = *const fn (Route, *jetzig.http.StaticRequest) anyerror!jetzig.views.View;
 
-const ViewWithoutId = *const fn (*jetzig.http.Request, *jetzig.data.Data) anyerror!jetzig.views.View;
-const ViewWithId = *const fn (id: []const u8, *jetzig.http.Request, *jetzig.data.Data) anyerror!jetzig.views.View;
+pub const ViewWithoutId = *const fn (*jetzig.http.Request, *jetzig.data.Data) anyerror!jetzig.views.View;
+pub const ViewWithId = *const fn (id: []const u8, *jetzig.http.Request, *jetzig.data.Data) anyerror!jetzig.views.View;
 const StaticViewWithoutId = *const fn (*jetzig.http.StaticRequest, *jetzig.data.Data) anyerror!jetzig.views.View;
 const StaticViewWithId = *const fn (id: []const u8, *jetzig.http.StaticRequest, *jetzig.data.Data) anyerror!jetzig.views.View;
 
@@ -20,6 +20,7 @@ pub const DynamicViewType = union(Action) {
     put: ViewWithId,
     patch: ViewWithId,
     delete: ViewWithId,
+    custom: CustomViewType,
 };
 
 pub const StaticViewType = union(Action) {
@@ -29,23 +30,30 @@ pub const StaticViewType = union(Action) {
     put: StaticViewWithId,
     patch: StaticViewWithId,
     delete: StaticViewWithId,
+    custom: void,
+};
+
+pub const CustomViewType = union(enum) {
+    with_id: ViewWithId,
+    without_id: ViewWithoutId,
 };
 
 pub const ViewType = union(enum) {
     static: StaticViewType,
     dynamic: DynamicViewType,
+    custom: CustomViewType,
 };
 
 name: []const u8,
 action: Action,
+method: jetzig.http.Request.Method = undefined, // Used by custom routes only
 view_name: []const u8,
 uri_path: []const u8,
-view: ?ViewType = null,
-static_view: ?StaticViewType = null,
-static: bool,
+view: ViewType,
 render: RenderFn = renderFn,
 renderStatic: RenderStaticFn = renderStaticFn,
-layout: ?[]const u8,
+static: bool = false,
+layout: ?[]const u8 = null,
 template: []const u8,
 json_params: []const []const u8,
 params: std.ArrayList(*jetzig.data.Data) = undefined,
@@ -70,34 +78,56 @@ pub fn deinitParams(self: *const Route) void {
     self.params.deinit();
 }
 
+/// Match a **custom** route to a request - not used by auto-generated route matching.
+pub fn match(self: Route, request: *const jetzig.http.Request) bool {
+    if (self.method != request.method) return false;
+
+    var request_path_it = std.mem.splitScalar(u8, request.path.base_path, '/');
+    var uri_path_it = std.mem.splitScalar(u8, self.uri_path, '/');
+
+    while (uri_path_it.next()) |expected_segment| {
+        const actual_segment = request_path_it.next() orelse return false;
+        if (std.mem.startsWith(u8, expected_segment, ":")) continue;
+        if (!std.mem.eql(u8, expected_segment, actual_segment)) return false;
+    }
+
+    return true;
+}
+
 fn renderFn(self: Route, request: *jetzig.http.Request) anyerror!jetzig.views.View {
-    switch (self.view.?) {
+    switch (self.view) {
         .dynamic => {},
+        .custom => |view_type| switch (view_type) {
+            .with_id => |view| return try view(request.path.resourceId(self), request, request.response_data),
+            .without_id => |view| return try view(request, request.response_data),
+        },
         // We only end up here if a static route is defined but its output is not found in the
         // file system (e.g. if it was manually deleted after build). This should be avoidable by
         // including the content as an artifact in the compiled executable (TODO):
         .static => return error.JetzigMissingStaticContent,
     }
 
-    switch (self.view.?.dynamic) {
+    switch (self.view.dynamic) {
         .index => |view| return try view(request, request.response_data),
         .get => |view| return try view(request.path.resource_id, request, request.response_data),
         .post => |view| return try view(request, request.response_data),
         .patch => |view| return try view(request.path.resource_id, request, request.response_data),
         .put => |view| return try view(request.path.resource_id, request, request.response_data),
         .delete => |view| return try view(request.path.resource_id, request, request.response_data),
+        .custom => unreachable,
     }
 }
 
 fn renderStaticFn(self: Route, request: *jetzig.http.StaticRequest) anyerror!jetzig.views.View {
     request.response_data.* = jetzig.data.Data.init(request.allocator);
 
-    switch (self.view.?.static) {
+    switch (self.view.static) {
         .index => |view| return try view(request, request.response_data),
         .get => |view| return try view(try request.resourceId(), request, request.response_data),
         .post => |view| return try view(request, request.response_data),
         .patch => |view| return try view(try request.resourceId(), request, request.response_data),
         .put => |view| return try view(try request.resourceId(), request, request.response_data),
         .delete => |view| return try view(try request.resourceId(), request, request.response_data),
+        .custom => unreachable,
     }
 }


### PR DESCRIPTION
In `main()`:

```zig
    app.route(.GET, "/custom/:id/foo/bar", @import("app/views/custom/foo.zig"), .bar);
```

Routes `GET` request with path (e.g.) `/custom/1234/foo/bar` to `bar()` defined in `src/app/views/custom/foo.zig`.

Routes with an `:id` segment expect a function with three parameters, routes without an `:id` segment expect a function with two parameters (i.e. the same as `get` vs `index`).