### PR TITLE
Update Zmpl for template inheritance

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
             .hash = "12203b56c2e17a2fd62ea3d3d9be466f43921a3aef88b381cf58f41251815205fdb5",
         },
         .zmpl = .{
-            .url = "https://github.com/jetzig-framework/zmpl/archive/918b74353c5680b54b435dcacd67268b23ffa129.tar.gz",
-            .hash = "1220bf01968a822771a33bb51e37ff8ee13d21437f95ec55150ffa7c6a9fb1dfcbc5",
+            .url = "https://github.com/jetzig-framework/zmpl/archive/aa4d8ad5b63976d96e3b2c187f5b0b2c693905a1.tar.gz",
+            .hash = "1220b6dfedaf6ad2b464ebcec2aafdc01ba593a07a53885033d56c50a5a04334b517",
         },
         .jetkv = .{
             .url = "https://github.com/jetzig-framework/jetkv/archive/78bcdcc6b0cbd3ca808685c64554a15701f13250.tar.gz",

--- a/demo/src/app/views/quotes.zig
+++ b/demo/src/app/views/quotes.zig
@@ -24,7 +24,6 @@ pub fn post(request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
     const params = try request.params();
     try root.put("param", params.get("foo").?);
 
-    std.debug.print("{}\n", .{params});
     return request.render(.ok);
 }
 

--- a/src/jetzig.zig
+++ b/src/jetzig.zig
@@ -44,7 +44,9 @@ pub const View = views.View;
 /// A route definition. Generated at build type by `Routes.zig`.
 pub const Route = views.Route;
 
-const root = @import("root");
+/// A middleware route definition. Allows middleware to define custom routes in order to serve
+/// content.
+pub const MiddlewareRoute = middleware.MiddlewareRoute;
 
 /// An asynchronous job that runs outside of the request/response flow. Create via `Request.job`
 /// and set params with `Job.put`, then call `Job.schedule()` to add to the
@@ -60,6 +62,8 @@ pub const MailerDefinition = mail.MailerDefinition;
 /// A generic logger type. Provides all standard log levels as functions (`INFO`, `WARN`,
 /// `ERROR`, etc.). Note that all log functions are CAPITALIZED.
 pub const Logger = loggers.Logger;
+
+const root = @import("root");
 
 /// Global configuration. Override these values by defining in `src/main.zig` with:
 /// ```zig

--- a/src/jetzig/http/Path.zig
+++ b/src/jetzig/http/Path.zig
@@ -54,6 +54,30 @@ pub fn resourceId(self: Self, route: jetzig.views.Route) []const u8 {
     return self.resource_id;
 }
 
+pub fn resourceArgs(self: Self, route: jetzig.views.Route, allocator: std.mem.Allocator) ![]const []const u8 {
+    var args = std.ArrayList([]const u8).init(allocator);
+    var route_uri_path_it = std.mem.splitScalar(u8, route.uri_path, '/');
+    var path_it = std.mem.splitScalar(u8, self.base_path, '/');
+
+    var matched = false;
+
+    while (path_it.next()) |path_segment| {
+        const route_uri_path_segment = route_uri_path_it.next();
+        if (!matched and
+            route_uri_path_segment != null and
+            std.mem.startsWith(u8, route_uri_path_segment.?, ":") and
+            std.mem.endsWith(u8, route_uri_path_segment.?, "*"))
+        {
+            matched = true;
+        }
+        if (matched) {
+            try args.append(path_segment);
+        }
+    }
+
+    return try args.toOwnedSlice();
+}
+
 // Extract `"/foo/bar/baz"` from:
 // * `"/foo/bar/baz"`
 // * `"/foo/bar/baz.html"`

--- a/src/jetzig/http/Request.zig
+++ b/src/jetzig/http/Request.zig
@@ -27,6 +27,7 @@ _cookies: ?*jetzig.http.Cookies = null,
 _session: ?*jetzig.http.Session = null,
 body: []const u8 = undefined,
 processed: bool = false,
+dynamic_assigned_template: ?[]const u8 = null,
 layout: ?[]const u8 = null,
 layout_disabled: bool = false,
 rendered: bool = false,
@@ -511,6 +512,21 @@ pub fn formatStatus(self: *const Request, status_code: jetzig.http.StatusCode) !
         }, .{}),
         .HTML, .UNKNOWN => status.getFormatted(.{ .linebreak = true }),
     };
+}
+
+/// Override default template name for a matched route.
+pub fn setTemplate(self: *Request, name: []const u8) void {
+    self.dynamic_assigned_template = name;
+}
+
+pub fn joinPaths(self: *const Request, paths: []const []const []const u8) ![]const u8 {
+    var buf = std.ArrayList([]const u8).init(self.allocator);
+    defer buf.deinit();
+
+    for (paths) |subpaths| {
+        for (subpaths) |path| try buf.append(path);
+    }
+    return try std.mem.join(self.allocator, "/", buf.items);
 }
 
 pub fn setResponse(

--- a/src/jetzig/middleware.zig
+++ b/src/jetzig/middleware.zig
@@ -1,1 +1,35 @@
+const std = @import("std");
+const jetzig = @import("../jetzig.zig");
+
 pub const HtmxMiddleware = @import("middleware/HtmxMiddleware.zig");
+
+const RouteOptions = struct {
+    content: ?[]const u8 = null,
+    content_type: []const u8 = "text/html",
+    status: jetzig.http.StatusCode = .ok,
+};
+
+pub const MiddlewareRoute = struct {
+    method: jetzig.http.Request.Method,
+    path: []const u8,
+    content: ?[]const u8,
+    content_type: []const u8,
+    status: jetzig.http.StatusCode,
+
+    pub fn match(self: MiddlewareRoute, request: *const jetzig.http.Request) bool {
+        if (self.method != request.method) return false;
+        if (!std.mem.eql(u8, self.path, request.path.file_path)) return false;
+
+        return true;
+    }
+};
+
+pub fn route(method: jetzig.http.Request.Method, path: []const u8, options: RouteOptions) MiddlewareRoute {
+    return .{
+        .method = method,
+        .path = path,
+        .content = options.content,
+        .content_type = options.content_type,
+        .status = options.status,
+    };
+}

--- a/src/jetzig/middleware/HtmxMiddleware.zig
+++ b/src/jetzig/middleware/HtmxMiddleware.zig
@@ -1,20 +1,13 @@
 const std = @import("std");
 const jetzig = @import("../../jetzig.zig");
 
-const Self = @This();
-
-/// Initialize htmx middleware.
-pub fn init(request: *jetzig.http.Request) !*Self {
-    const middleware = try request.allocator.create(Self);
-    return middleware;
-}
+const HtmxMiddleware = @This();
 
 /// Detects the `HX-Request` header and, if present, disables the default layout for the current
 /// request. This allows a view to specify a layout that will render the full page when the
 /// request doesn't come via htmx and, when the request does come from htmx, only return the
 /// content rendered directly by the view function.
-pub fn afterRequest(self: *Self, request: *jetzig.http.Request) !void {
-    _ = self;
+pub fn afterRequest(request: *jetzig.http.Request) !void {
     if (request.headers.get("HX-Target")) |target| {
         try request.server.logger.DEBUG(
             "[middleware-htmx] htmx request detected, disabling layout. (#{s})",
@@ -26,8 +19,7 @@ pub fn afterRequest(self: *Self, request: *jetzig.http.Request) !void {
 
 /// If a redirect was issued during request processing, reset any response data, set response
 /// status to `200 OK` and replace the `Location` header with a `HX-Redirect` header.
-pub fn beforeResponse(self: *Self, request: *jetzig.http.Request, response: *jetzig.http.Response) !void {
-    _ = self;
+pub fn beforeResponse(request: *const jetzig.http.Request, response: *jetzig.http.Response) !void {
     if (response.status_code != .moved_permanently and response.status_code != .found) return;
     if (request.headers.get("HX-Request") == null) return;
 
@@ -36,9 +28,4 @@ pub fn beforeResponse(self: *Self, request: *jetzig.http.Request, response: *jet
         request.response_data.reset();
         try response.headers.append("HX-Redirect", location);
     }
-}
-
-/// Clean up the allocated htmx middleware.
-pub fn deinit(self: *Self, request: *jetzig.http.Request) void {
-    request.allocator.destroy(self);
 }


### PR DESCRIPTION
Permit setting template during view render with `request.setTemplate()`

Permit middleware to define custom routes to static content with `pub const Routes` (implemented for something no longer needed but seems useful anyway).

Implement globbing on custom routes, `/foo/:bar*` will glob all path segments including and after `/foo/...`, e.g. `/foo/bar/baz/qux` will pass invoke the custom view function with an array of `bar`, `baz`, `qux` as first argument (instead of typical resource ID).