### PR TITLE
Middleware request resolution

### DIFF
--- a/demo/src/app/middleware/DemoMiddleware.zig
+++ b/demo/src/app/middleware/DemoMiddleware.zig
@@ -33,6 +33,12 @@ pub fn init(request: *jetzig.http.Request) !*DemoMiddleware {
 /// Any calls to `request.render` or `request.redirect` will prevent further processing of the
 /// request, including any other middleware in the chain.
 pub fn afterRequest(self: *DemoMiddleware, request: *jetzig.http.Request) !void {
+    // Middleware can invoke `request.redirect` or `request.render`. All request processing stops
+    // and the response is immediately returned if either of these two functions are called
+    // during middleware processing.
+    // _ = request.redirect("/foobar", .moved_permanently);
+    // _ = request.render(.unauthorized);
+
     try request.server.logger.DEBUG(
         "[DemoMiddleware:afterRequest] my_custom_value: {s}",
         .{self.my_custom_value},

--- a/demo/src/app/views/301.zmpl
+++ b/demo/src/app/views/301.zmpl
@@ -1,0 +1,1 @@
+Redirecting to <a href="{{.location}}">{{.location}}</a>

--- a/demo/src/main.zig
+++ b/demo/src/main.zig
@@ -16,39 +16,55 @@ pub const jetzig_options = struct {
         jetzig.middleware.HtmxMiddleware,
         // Demo middleware included with new projects. Remove once you are familiar with Jetzig's
         // middleware system.
-        // @import("app/middleware/DemoMiddleware.zig"),
+        @import("app/middleware/DemoMiddleware.zig"),
     };
 
     // Maximum bytes to allow in request body.
-    // pub const max_bytes_request_body: usize = std.math.pow(usize, 2, 16);
+    pub const max_bytes_request_body: usize = std.math.pow(usize, 2, 16);
 
     // Maximum filesize for `public/` content.
-    // pub const max_bytes_public_content: usize = std.math.pow(usize, 2, 20);
+    pub const max_bytes_public_content: usize = std.math.pow(usize, 2, 20);
 
     // Maximum filesize for `static/` content (applies only to apps using `jetzig.http.StaticRequest`).
-    // pub const max_bytes_static_content: usize = std.math.pow(usize, 2, 18);
+    pub const max_bytes_static_content: usize = std.math.pow(usize, 2, 18);
 
     // Maximum length of a header name. There is no limit imposed by the HTTP specification but
     // AWS load balancers reference 40 as a limit so we use that as a baseline:
     // https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_HttpHeaderConditionConfig.html
     // This can be increased if needed.
-    // pub const max_bytes_header_name: u16 = 40;
+    pub const max_bytes_header_name: u16 = 40;
 
     // Log message buffer size. Log messages exceeding this size spill to heap with degraded
     // performance. Log messages should aim to fit in the message buffer.
-    // pub const log_message_buffer_len: usize = 4096;
+    pub const log_message_buffer_len: usize = 4096;
 
     // Maximum log pool size. When a log buffer is no longer required it is returned to a pool
     // for recycling. When logging i/o is slow, a high volume of requests will result in this
     // pool growing. When the pool size reaches the maximum value defined here, log events are
     // freed instead of recycled.
-    // pub const max_log_pool_len: usize = 256;
+    pub const max_log_pool_len: usize = 256;
+
+    // Number of request threads. Defaults to number of detected CPUs.
+    pub const thread_count: ?u16 = null;
+
+    // Number of response worker threads.
+    pub const worker_count: u16 = 4;
+
+    // Total number of connections managed by worker threads.
+    pub const max_connections: u16 = 512;
+
+    // Per-thread stack memory to use before spilling into request arena (possibly with allocations).
+    pub const buffer_size: usize = 64 * 1024;
+
+    // The size of each item in the available memory pool used by requests for rendering.
+    // Total retained allocation: `worker_count * max_connections`.
+    pub const arena_size: usize = 1024 * 1024;
 
     // Path relative to cwd() to serve public content from. Symlinks are not followed.
-    // pub const public_content_path = "public";
+    pub const public_content_path = "public";
 
     // HTTP buffer. Must be large enough to store all headers. This should typically not be modified.
-    // pub const http_buffer_size: usize = std.math.pow(usize, 2, 16);
+    pub const http_buffer_size: usize = std.math.pow(usize, 2, 16);
 
     // The number of worker threads to spawn on startup for processing Jobs (NOT the number of
     // HTTP server worker threads).
@@ -56,7 +72,7 @@ pub const jetzig_options = struct {
 
     // Duration before looking for more Jobs when the queue is found to be empty, in
     // milliseconds.
-    // pub const job_worker_sleep_interval_ms: usize = 10;
+    pub const job_worker_sleep_interval_ms: usize = 10;
 
     /// Key-value store options. Set backend to `.file` to use a file-based store.
     /// When using `.file` backend, you must also set `.file_options`.
@@ -108,7 +124,7 @@ pub const jetzig_options = struct {
     // };
 
     /// Force email delivery in development mode (instead of printing email body to logger).
-    // pub const force_development_email_delivery = false;
+    pub const force_development_email_delivery = false;
 
     // Set custom fragments for rendering markdown templates. Any values will fall back to
     // defaults provided by Zmd (https://github.com/jetzig-framework/zmd/blob/main/src/zmd/html.zig).

--- a/src/jetzig.zig
+++ b/src/jetzig.zig
@@ -101,15 +101,20 @@ pub const config = struct {
     /// Number of request threads. Defaults to number of detected CPUs.
     pub const thread_count: ?u16 = null;
 
+    /// Per-thread stack memory to use before spilling into request arena (possibly with allocations).
+    pub const buffer_size: usize = 64 * 1024;
+
+    /// The pre-heated size of each item in the available memory pool used by requests for
+    /// rendering. Total retained allocation: `worker_count * max_connections`. Requests
+    /// requiring more memory will allocate per-request, leaving `arena_size` bytes pre-allocated
+    /// for the next request.
+    pub const arena_size: usize = 1024 * 1024;
+
     /// Number of response worker threads.
     pub const worker_count: u16 = 4;
 
     /// Total number of connections managed by worker threads.
     pub const max_connections: u16 = 512;
-
-    /// The size of each item in the available memory pool used by requests for rendering.
-    /// Total retained allocation: `worker_count * max_connections`.
-    pub const arena_size: usize = 1024 * 1024;
 
     /// Path relative to cwd() to serve public content from. Symlinks are not followed.
     pub const public_content_path = "public";

--- a/src/jetzig/colors.zig
+++ b/src/jetzig/colors.zig
@@ -5,7 +5,7 @@ const builtin = @import("builtin");
 const types = @import("types.zig");
 
 // Must be consistent with `std.io.tty.Color` for Windows compatibility.
-const codes = .{
+pub const codes = .{
     .escape = "\x1b[",
     .black = "30m",
     .red = "31m",

--- a/src/jetzig/http.zig
+++ b/src/jetzig/http.zig
@@ -14,3 +14,7 @@ pub const status_codes = @import("http/status_codes.zig");
 pub const StatusCode = status_codes.StatusCode;
 pub const middleware = @import("http/middleware.zig");
 pub const mime = @import("http/mime.zig");
+
+pub const SimplifiedRequest = struct {
+    location: ?[]const u8,
+};

--- a/src/jetzig/loggers/DevelopmentLogger.zig
+++ b/src/jetzig/loggers/DevelopmentLogger.zig
@@ -84,12 +84,22 @@ pub fn logRequest(self: DevelopmentLogger, request: *const jetzig.http.Request) 
 
     const formatted_level = if (self.stdout_colorized) colorizedLogLevel(.INFO) else @tagName(.INFO);
 
-    try self.log_queue.print("{s: >5} [{s}] [{s}/{s}/{s}] {s}\n", .{
+    try self.log_queue.print("{s: >5} [{s}] [{s}/{s}/{s}]{s}{s}{s}{s}{s}{s}{s}{s}{s}{s} {s}\n", .{
         formatted_level,
         iso8601,
         formatted_duration,
         request.fmtMethod(self.stdout_colorized),
         formatted_status,
+        if (request.middleware_rendered) |_| " [" ++ jetzig.colors.codes.escape ++ jetzig.colors.codes.magenta else "",
+        if (request.middleware_rendered) |middleware| middleware.name else "",
+        if (request.middleware_rendered) |_| jetzig.colors.codes.escape ++ jetzig.colors.codes.white ++ ":" else "",
+        if (request.middleware_rendered) |_| jetzig.colors.codes.escape ++ jetzig.colors.codes.blue else "",
+        if (request.middleware_rendered) |middleware| middleware.action else "",
+        if (request.middleware_rendered) |_| jetzig.colors.codes.escape ++ jetzig.colors.codes.white ++ ":" else "",
+        if (request.middleware_rendered) |_| jetzig.colors.codes.escape ++ jetzig.colors.codes.bright_cyan else "",
+        if (request.middleware_rendered) |_| if (request.redirected) "redirect" else "render" else "",
+        if (request.middleware_rendered) |_| jetzig.colors.codes.escape ++ jetzig.colors.codes.reset else "",
+        if (request.middleware_rendered) |_| "]" else "",
         request.path.path,
     }, .stdout);
 }

--- a/src/jetzig/middleware/HtmxMiddleware.zig
+++ b/src/jetzig/middleware/HtmxMiddleware.zig
@@ -19,7 +19,7 @@ pub fn afterRequest(request: *jetzig.http.Request) !void {
 
 /// If a redirect was issued during request processing, reset any response data, set response
 /// status to `200 OK` and replace the `Location` header with a `HX-Redirect` header.
-pub fn beforeResponse(request: *const jetzig.http.Request, response: *jetzig.http.Response) !void {
+pub fn beforeResponse(request: *jetzig.http.Request, response: *jetzig.http.Response) !void {
     if (response.status_code != .moved_permanently and response.status_code != .found) return;
     if (request.headers.get("HX-Request") == null) return;
 


### PR DESCRIPTION
Allow middleware to resolve a request by calling `request.redirect` or `request.render` - after this point, the request stops processing and renders immediately.