### PR TITLE
Implement response format constraints

### DIFF
--- a/demo/src/app/views/format.zig
+++ b/demo/src/app/views/format.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const jetzig = @import("jetzig");
+
+// Define `pub const formats` to apply constraints to specific view functions. By default, all
+// view functions respond to `json` and `html` requests. Use this feature to override those
+// defaults.
+pub const formats: jetzig.Route.Formats = .{
+    .index = &.{ .json, .html },
+    .get = &.{.html},
+};
+
+pub fn index(request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    _ = data;
+    return request.render(.ok);
+}
+
+pub fn get(id: []const u8, request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    _ = data;
+    _ = id;
+    return request.render(.ok);
+}
+
+test "index (json)" {
+    var app = try jetzig.testing.app(std.testing.allocator, @import("routes"));
+    defer app.deinit();
+
+    const response = try app.request(.GET, "/format.json", .{});
+    try response.expectStatus(.ok);
+}
+
+test "index (html)" {
+    var app = try jetzig.testing.app(std.testing.allocator, @import("routes"));
+    defer app.deinit();
+
+    const response = try app.request(.GET, "/format.html", .{});
+    try response.expectStatus(.ok);
+}
+
+test "get (html)" {
+    var app = try jetzig.testing.app(std.testing.allocator, @import("routes"));
+    defer app.deinit();
+
+    const response = try app.request(.GET, "/format/example-id.html", .{});
+    try response.expectStatus(.ok);
+}
+
+test "get (json)" {
+    var app = try jetzig.testing.app(std.testing.allocator, @import("routes"));
+    defer app.deinit();
+
+    const response = try app.request(.GET, "/format/example-id.json", .{});
+    try response.expectStatus(.not_found);
+}

--- a/demo/src/app/views/format/get.zmpl
+++ b/demo/src/app/views/format/get.zmpl
@@ -1,0 +1,3 @@
+<div>
+  <span>Content goes here</span>
+</div>

--- a/demo/src/app/views/format/index.zmpl
+++ b/demo/src/app/views/format/index.zmpl
@@ -1,0 +1,3 @@
+<div>
+  <span>Content goes here</span>
+</div>

--- a/src/Routes.zig
+++ b/src/Routes.zig
@@ -278,6 +278,7 @@ fn writeRoute(self: *Routes, writer: std.ArrayList(u8).Writer, route: Function) 
         \\            .template = "{6s}",
         \\            .layout = if (@hasDecl(@import("{7s}"), "layout")) @import("{7s}").layout else null,
         \\            .json_params = &[_][]const u8 {{ {8s} }},
+        \\            .formats = if (@hasDecl(@import("{7s}"), "formats")) @import("{7s}").formats else null,
         \\        }},
         \\
     ;

--- a/src/jetzig/App.zig
+++ b/src/jetzig/App.zig
@@ -207,6 +207,7 @@ pub fn createRoutes(
             .layout = const_route.layout,
             .template = const_route.template,
             .json_params = const_route.json_params,
+            .formats = const_route.formats,
         };
 
         try var_route.initParams(allocator);

--- a/src/jetzig/http/Server.zig
+++ b/src/jetzig/http/Server.zig
@@ -192,6 +192,12 @@ fn renderResponse(self: *Server, request: *jetzig.http.Request) !void {
 
     const route = self.matchCustomRoute(request) orelse try self.matchRoute(request, false);
 
+    if (route) |capture| {
+        if (!capture.validateFormat(request)) {
+            return request.setResponse(try self.renderNotFound(request), .{});
+        }
+    }
+
     switch (request.requestFormat()) {
         .HTML => try self.renderHTML(request, route),
         .JSON => try self.renderJSON(request, route),

--- a/src/routes_exe.zig
+++ b/src/routes_exe.zig
@@ -23,7 +23,7 @@ pub fn main() !void {
             .index => jetzig.colors.blue("{s: <7}"),
             .post => jetzig.colors.yellow("{s: <7}"),
             .put => jetzig.colors.magenta("{s: <7}"),
-            .patch => jetzig.colors.purple("{s: <7}"),
+            .patch => jetzig.colors.bright_magenta("{s: <7}"),
             .delete => jetzig.colors.red("{s: <7}"),
             .custom => unreachable,
         };

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -37,7 +37,7 @@ const Test = struct {
         trace: ?[]const u8,
     };
 
-    const name_template = jetzig.colors.blue("{s}") ++ jetzig.colors.yellow("->") ++ "\"" ++ jetzig.colors.cyan("{s}") ++ "\" ";
+    const name_template = jetzig.colors.blue("{s}") ++ jetzig.colors.yellow("::") ++ "\"" ++ jetzig.colors.cyan("{s}") ++ "\" ";
 
     pub fn init(test_fn: std.builtin.TestFn) Test {
         return if (std.mem.indexOf(u8, test_fn.name, ".test.")) |index|


### PR DESCRIPTION
Define `pub const formats` in a view to specify which formats are available. Use this to e.g. disable JSON responses.