### PR TITLE
Fix database launch message

### DIFF
--- a/src/jetzig/Environment.zig
+++ b/src/jetzig/Environment.zig
@@ -272,8 +272,13 @@ pub fn init(parent_allocator: std.mem.Allocator, env_options: EnvironmentOptions
             .{
                 @tagName(jetzig.database.adapter),
                 switch (jetzig.environment) {
-                    inline else => |tag| vars.get("JETQUERY_DATABASE") orelse
-                        @field(jetzig.jetquery.config.database, @tagName(tag)).database,
+                    inline else => |tag| vars.get("JETQUERY_DATABASE") orelse blk: {
+                        const config = @field(jetzig.jetquery.config.database, @tagName(tag));
+                        break :blk if (comptime @hasField(@TypeOf(config), "database"))
+                            config.database
+                        else
+                            "[no database]";
+                    },
                 },
             },
         );


### PR DESCRIPTION
When an environment variable configures the database name we connect to, we need to wrap the field access in a comptime check even if the `orelse` block never runs.