### PR TITLE
Closes #108: Anti-CSRF middleware

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run App Tests
         run: |
           cd demo
-          zig build jetzig:test
+          zig build -Denvironment=testing jetzig:test
 
       - name: Build artifacts
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
             .hash = "1220d0e8734628fd910a73146e804d10a3269e3e7d065de6bb0e3e88d5ba234eb163",
         },
         .zmpl = .{
-            .url = "https://github.com/jetzig-framework/zmpl/archive/25b91d030b992631d319adde1cf01baecd9f3934.tar.gz",
-            .hash = "12208dd5a4bf0c6c7efc4e9f37a5d8ed80d6004d5680176d1fc2114bfa593e927baf",
+            .url = "https://github.com/jetzig-framework/zmpl/archive/af75c8b842c3957eb97b4fc4bc49c7b2243968fa.tar.gz",
+            .hash = "1220ecac93d295dafd2f034a86f0979f6108d40e5ea1a39e3a2b9977c35147cac684",
         },
         .jetkv = .{
             .url = "https://github.com/jetzig-framework/jetkv/archive/2b1130a48979ea2871c8cf6ca89c38b1e7062839.tar.gz",

--- a/demo/src/app/views/anti_csrf.zig
+++ b/demo/src/app/views/anti_csrf.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const jetzig = @import("jetzig");
+
+pub const layout = "application";
+
+pub const actions = .{
+    .before = .{jetzig.middleware.AntiCsrfMiddleware},
+};
+
+pub fn post(request: *jetzig.Request) !jetzig.View {
+    var root = try request.data(.object);
+
+    const Params = struct { spam: []const u8 };
+    const params = try request.expectParams(Params) orelse {
+        return request.fail(.unprocessable_entity);
+    };
+
+    try root.put("spam", params.spam);
+
+    return request.render(.created);
+}
+
+pub fn index(request: *jetzig.Request) !jetzig.View {
+    return request.render(.ok);
+}
+
+test "post with missing token" {
+    var app = try jetzig.testing.app(std.testing.allocator, @import("routes"));
+    defer app.deinit();
+
+    const response = try app.request(.POST, "/anti_csrf", .{});
+    try response.expectStatus(.forbidden);
+}
+
+test "post with invalid token" {
+    var app = try jetzig.testing.app(std.testing.allocator, @import("routes"));
+    defer app.deinit();
+
+    const response = try app.request(.POST, "/anti_csrf", .{});
+    try response.expectStatus(.forbidden);
+}
+
+test "post with valid token but missing expected params" {
+    var app = try jetzig.testing.app(std.testing.allocator, @import("routes"));
+    defer app.deinit();
+
+    _ = try app.request(.GET, "/anti_csrf", .{});
+    const token = app.session.getT(.string, jetzig.authenticity_token_name).?;
+    const response = try app.request(
+        .POST,
+        "/anti_csrf",
+        .{ .params = .{ ._jetzig_authenticity_token = token } },
+    );
+    try response.expectStatus(.unprocessable_entity);
+}
+
+test "post with valid token and expected params" {
+    var app = try jetzig.testing.app(std.testing.allocator, @import("routes"));
+    defer app.deinit();
+
+    _ = try app.request(.GET, "/anti_csrf", .{});
+    const token = app.session.getT(.string, jetzig.authenticity_token_name).?;
+    const response = try app.request(
+        .POST,
+        "/anti_csrf",
+        .{ .params = .{ ._jetzig_authenticity_token = token, .spam = "Spam" } },
+    );
+    try response.expectStatus(.created);
+}
+
+test "index" {
+    var app = try jetzig.testing.app(std.testing.allocator, @import("routes"));
+    defer app.deinit();
+
+    const response = try app.request(.GET, "/anti_csrf", .{});
+    try response.expectStatus(.ok);
+}

--- a/demo/src/app/views/anti_csrf/index.zmpl
+++ b/demo/src/app/views/anti_csrf/index.zmpl
@@ -1,0 +1,8 @@
+<form action="/anti_csrf" method="POST">
+    {{context.authenticityFormElement()}}
+
+    <label>Enter spam here:</label>
+    <input type="text" name="spam" />
+
+    <input type="submit" value="Submit Spam" />
+</form>

--- a/demo/src/app/views/anti_csrf/post.zmpl
+++ b/demo/src/app/views/anti_csrf/post.zmpl
@@ -1,0 +1,5 @@
+<h1>Spam Submitted Successfully</h1>
+
+<h2>Spam:</h2>
+
+<div>{{$.spam}}</div>

--- a/demo/src/main.zig
+++ b/demo/src/main.zig
@@ -12,6 +12,8 @@ pub const jetzig_options = struct {
     /// Middleware chain. Add any custom middleware here, or use middleware provided in
     /// `jetzig.middleware` (e.g. `jetzig.middleware.HtmxMiddleware`).
     pub const middleware: []const type = &.{
+        // jetzig.middleware.AuthMiddleware,
+        // jetzig.middleware.AntiCsrfMiddleware,
         // jetzig.middleware.HtmxMiddleware,
         // jetzig.middleware.CompressionMiddleware,
         // @import("app/middleware/DemoMiddleware.zig"),
@@ -79,13 +81,16 @@ pub const jetzig_options = struct {
     pub const Schema = @import("Schema");
 
     /// HTTP cookie configuration
-    pub const cookies: jetzig.http.Cookies.CookieOptions = .{
-        .domain = switch (jetzig.environment) {
-            .development => "localhost",
-            .testing => "localhost",
-            .production => "www.example.com",
+    pub const cookies: jetzig.http.Cookies.CookieOptions = switch (jetzig.environment) {
+        .development, .testing => .{
+            .domain = "localhost",
+            .path = "/",
         },
-        .path = "/",
+        .production => .{
+            .same_site = true,
+            .secure = true,
+            .http_only = true,
+        },
     };
 
     /// Key-value store options. Set backend to `.file` to use a file-based store.

--- a/src/Routes.zig
+++ b/src/Routes.zig
@@ -280,6 +280,8 @@ fn writeRoute(self: *Routes, writer: std.ArrayList(u8).Writer, route: Function) 
         \\            .static = {4s},
         \\            .uri_path = "{5s}",
         \\            .template = "{6s}",
+        \\            .before_callbacks = jetzig.callbacks.beforeCallbacks(@import("{7s}")),
+        \\            .after_callbacks = jetzig.callbacks.afterCallbacks(@import("{7s}")),
         \\            .layout = if (@hasDecl(@import("{7s}"), "layout")) @import("{7s}").layout else null,
         \\            .json_params = &[_][]const u8 {{ {8s} }},
         \\            .formats = if (@hasDecl(@import("{7s}"), "formats")) @import("{7s}").formats else null,
@@ -389,7 +391,7 @@ fn generateRoutesForView(self: *Routes, dir: std.fs.Dir, path: []const u8) !Rout
 
                     for (capture.args, 0..) |arg, arg_index| {
                         if (std.mem.eql(u8, try arg.typeBasename(), "StaticRequest")) {
-                            capture.static = true;
+                            capture.static = jetzig.build_options.build_static;
                             capture.legacy = arg_index + 1 < capture.args.len;
                             try static_routes.append(capture.*);
                         } else if (std.mem.eql(u8, try arg.typeBasename(), "Request")) {

--- a/src/commands/routes.zig
+++ b/src/commands/routes.zig
@@ -13,7 +13,7 @@ pub fn main() !void {
 
     log("Jetzig Routes:", .{});
 
-    const environment = jetzig.Environment.init(allocator, .{ .silent = true });
+    const environment = try jetzig.Environment.init(allocator, .{ .silent = true });
     const initHook: ?*const fn (*jetzig.App) anyerror!void = if (@hasDecl(app, "init")) app.init else null;
 
     inline for (routes.routes) |route| max_uri_path_len = @max(route.uri_path.len + 5, max_uri_path_len);
@@ -44,7 +44,7 @@ pub fn main() !void {
     }
 
     var jetzig_app = jetzig.App{
-        .environment = environment,
+        .env = environment,
         .allocator = allocator,
         .custom_routes = std.ArrayList(jetzig.views.Route).init(allocator),
         .initHook = initHook,

--- a/src/compile_static_routes.zig
+++ b/src/compile_static_routes.zig
@@ -147,7 +147,7 @@ fn renderMarkdown(
 
         if (zmpl.findPrefixed("views", prefixed_name)) |layout| {
             view.data.content = .{ .data = content };
-            return try layout.render(view.data);
+            return try layout.render(view.data, jetzig.TemplateContext, .{}, .{});
         } else {
             std.debug.print("Unknown layout: {s}\n", .{layout_name});
             return content;
@@ -170,13 +170,18 @@ fn renderZmplTemplate(
             defer allocator.free(prefixed_name);
 
             if (zmpl.findPrefixed("views", prefixed_name)) |layout| {
-                return try template.renderWithOptions(view.data, .{ .layout = layout });
+                return try template.render(
+                    view.data,
+                    jetzig.TemplateContext,
+                    .{},
+                    .{ .layout = layout },
+                );
             } else {
                 std.debug.print("Unknown layout: {s}\n", .{layout_name});
                 return try allocator.dupe(u8, "");
             }
         } else {
-            return try template.render(view.data);
+            return try template.render(view.data, jetzig.TemplateContext, .{}, .{});
         }
     } else return null;
 }

--- a/src/jetzig.zig
+++ b/src/jetzig.zig
@@ -22,10 +22,14 @@ pub const database = @import("jetzig/database.zig");
 pub const testing = @import("jetzig/testing.zig");
 pub const config = @import("jetzig/config.zig");
 pub const auth = @import("jetzig/auth.zig");
+pub const callbacks = @import("jetzig/callbacks.zig");
+pub const TemplateContext = @import("jetzig/TemplateContext.zig");
 
 pub const DateTime = jetcommon.types.DateTime;
 pub const Time = jetcommon.types.Time;
 pub const Date = jetcommon.types.Date;
+
+pub const authenticity_token_name = config.get([]const u8, "authenticity_token_name");
 
 pub const build_options = @import("build_options");
 pub const environment = std.enums.nameCast(Environment.EnvironmentName, build_options.environment);
@@ -45,6 +49,9 @@ pub const Request = http.Request;
 /// when building the application and then returned immediately to the client for matching
 /// requests.
 pub const StaticRequest = http.StaticRequest;
+
+/// An HTTP response generated during request processing.
+pub const Response = http.Response;
 
 /// Generic, JSON-compatible data type. Provides `Value` which in turn provides `Object`,
 /// `Array`, `String`, `Integer`, `Float`, `Boolean`, and `NullType`.
@@ -78,7 +85,8 @@ pub const Logger = loggers.Logger;
 
 pub const root = @import("root");
 pub const Global = if (@hasDecl(root, "Global")) root.Global else DefaultGlobal;
-pub const DefaultGlobal = struct { __jetzig_default: bool };
+pub const DefaultGlobal = struct { comptime __jetzig_default: bool = true };
+pub const default_global = DefaultGlobal{};
 
 pub const initHook: ?*const fn (*App) anyerror!void = if (@hasDecl(root, "init")) root.init else null;
 

--- a/src/jetzig/App.zig
+++ b/src/jetzig/App.zig
@@ -17,8 +17,8 @@ pub fn deinit(self: *const App) void {
     @constCast(self).custom_routes.deinit();
 }
 
-// Not used yet, but allows us to add new options to `start()` without breaking
-// backward-compatibility.
+/// Specify a global value accessible as `request.server.global`.
+/// Must specify type by defining `pub const Global` in your app's `src/main.zig`.
 const AppOptions = struct {
     global: *anyopaque = undefined,
 };
@@ -228,6 +228,8 @@ pub fn createRoutes(
             .template = const_route.template,
             .json_params = const_route.json_params,
             .formats = const_route.formats,
+            .before_callbacks = const_route.before_callbacks,
+            .after_callbacks = const_route.after_callbacks,
         };
 
         try var_route.initParams(allocator);

--- a/src/jetzig/TemplateContext.zig
+++ b/src/jetzig/TemplateContext.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+
+pub const http = @import("http.zig");
+pub const config = @import("config.zig");
+
+/// Context available in every Zmpl template as `context`.
+pub const TemplateContext = @This();
+
+request: ?*http.Request = null,
+
+pub fn authenticityToken(self: TemplateContext) !?[]const u8 {
+    return if (self.request) |request|
+        try request.authenticityToken()
+    else
+        null;
+}
+
+pub fn authenticityFormElement(self: TemplateContext) !?[]const u8 {
+    return if (self.request) |request| blk: {
+        const token = try request.authenticityToken();
+        break :blk try std.fmt.allocPrint(request.allocator,
+            \\<input type="hidden" name="{s}" value="{s}" />
+        , .{ config.get([]const u8, "authenticity_token_name"), token });
+    } else null;
+}

--- a/src/jetzig/callbacks.zig
+++ b/src/jetzig/callbacks.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+
+const jetzig = @import("../jetzig.zig");
+
+pub const BeforeCallback = *const fn (
+    *jetzig.http.Request,
+    jetzig.views.Route,
+) anyerror!void;
+
+pub const AfterCallback = *const fn (
+    *jetzig.http.Request,
+    *jetzig.http.Response,
+    jetzig.views.Route,
+) anyerror!void;
+
+pub const Context = enum { before, after };
+
+pub fn beforeCallbacks(view: type) []const BeforeCallback {
+    comptime {
+        return buildCallbacks(.before, view);
+    }
+}
+
+pub fn afterCallbacks(view: type) []const AfterCallback {
+    comptime {
+        return buildCallbacks(.after, view);
+    }
+}
+
+fn buildCallbacks(comptime context: Context, view: type) switch (context) {
+    .before => []const BeforeCallback,
+    .after => []const AfterCallback,
+} {
+    comptime {
+        if (!@hasDecl(view, "actions")) return &.{};
+        if (!@hasField(@TypeOf(view.actions), @tagName(context))) return &.{};
+
+        var size: usize = 0;
+        for (@field(view.actions, @tagName(context))) |module| {
+            if (isCallback(context, module)) {
+                size += 1;
+            } else {
+                @compileError(std.fmt.comptimePrint(
+                    "`{0s}` callbacks must be either a function `{1s}` or a type that defines " ++
+                        "`pub const {0s}Render`. Found: `{2s}`",
+                    .{
+                        @tagName(context),
+                        switch (context) {
+                            .before => @typeName(BeforeCallback),
+                            .after => @typeName(AfterCallback),
+                        },
+                        if (@TypeOf(module) == type)
+                            @typeName(module)
+                        else
+                            @typeName(@TypeOf(&module)),
+                    },
+                ));
+            }
+        }
+
+        var callbacks: [size]switch (context) {
+            .before => BeforeCallback,
+            .after => AfterCallback,
+        } = undefined;
+        var index: usize = 0;
+        for (@field(view.actions, @tagName(context))) |module| {
+            if (!isCallback(context, module)) continue;
+
+            callbacks[index] = if (@TypeOf(module) == type)
+                @field(module, @tagName(context) ++ "Render")
+            else
+                &module;
+
+            index += 1;
+        }
+
+        const final = callbacks;
+        return &final;
+    }
+}
+
+fn isCallback(comptime context: Context, comptime module: anytype) bool {
+    comptime {
+        if (@typeInfo(@TypeOf(module)) == .@"fn") {
+            const expected = switch (context) {
+                .before => BeforeCallback,
+                .after => AfterCallback,
+            };
+
+            const info = @typeInfo(@TypeOf(module)).@"fn";
+
+            const actual_params = info.params;
+            const expected_params = @typeInfo(@typeInfo(expected).pointer.child).@"fn".params;
+
+            if (actual_params.len != expected_params.len) return false;
+
+            for (actual_params, expected_params) |actual_param, expected_param| {
+                if (actual_param.type != expected_param.type) return false;
+            }
+
+            if (@typeInfo(info.return_type.?) != .error_union) return false;
+            if (@typeInfo(info.return_type.?).error_union.payload != void) return false;
+
+            return true;
+        }
+
+        return if (@TypeOf(module) == type and @hasDecl(module, @tagName(context) ++ "Render"))
+            true
+        else
+            false;
+    }
+}

--- a/src/jetzig/development_static.zig
+++ b/src/jetzig/development_static.zig
@@ -1,0 +1,12 @@
+pub const compiled = [_]Compiled{};
+
+const StaticOutput = struct {
+    json: ?[]const u8 = null,
+    html: ?[]const u8 = null,
+    params: ?[]const u8,
+};
+
+const Compiled = struct {
+    route_id: []const u8,
+    output: StaticOutput,
+};

--- a/src/jetzig/http.zig
+++ b/src/jetzig/http.zig
@@ -1,9 +1,14 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+pub const build_options = @import("build_options");
+
 pub const Server = @import("http/Server.zig");
 pub const Request = @import("http/Request.zig");
-pub const StaticRequest = @import("http/StaticRequest.zig");
+pub const StaticRequest = if (build_options.environment == .development)
+    Request
+else
+    @import("http/StaticRequest.zig");
 pub const Response = @import("http/Response.zig");
 pub const Session = @import("http/Session.zig");
 pub const Cookies = @import("http/Cookies.zig");

--- a/src/jetzig/http/Headers.zig
+++ b/src/jetzig/http/Headers.zig
@@ -46,10 +46,9 @@ pub fn getAll(self: Headers, name: []const u8) []const []const u8 {
     var headers = std.ArrayList([]const u8).init(self.allocator);
 
     for (self.httpz_headers.keys, 0..) |key, index| {
-        var buf: [max_bytes_header_name]u8 = undefined;
-        const lower = std.ascii.lowerString(&buf, name);
-
-        if (std.mem.eql(u8, lower, key)) headers.append(self.httpz_headers.values[index]) catch @panic("OOM");
+        if (std.ascii.eqlIgnoreCase(name, key)) {
+            headers.append(self.httpz_headers.values[index]) catch @panic("OOM");
+        }
     }
     return headers.toOwnedSlice() catch @panic("OOM");
 }

--- a/src/jetzig/mail/Job.zig
+++ b/src/jetzig/mail/Job.zig
@@ -134,7 +134,7 @@ fn defaultHtml(
     try data.addConst("jetzig_view", data.string(""));
     try data.addConst("jetzig_action", data.string(""));
     return if (jetzig.zmpl.findPrefixed("mailers", mailer.html_template)) |template|
-        try template.render(&data)
+        try template.render(&data, jetzig.TemplateContext, .{}, .{})
     else
         null;
 }
@@ -152,7 +152,7 @@ fn defaultText(
     try data.addConst("jetzig_view", data.string(""));
     try data.addConst("jetzig_action", data.string(""));
     return if (jetzig.zmpl.findPrefixed("mailers", mailer.text_template)) |template|
-        try template.render(&data)
+        try template.render(&data, jetzig.TemplateContext, .{}, .{})
     else
         null;
 }

--- a/src/jetzig/middleware.zig
+++ b/src/jetzig/middleware.zig
@@ -4,6 +4,7 @@ const jetzig = @import("../jetzig.zig");
 pub const HtmxMiddleware = @import("middleware/HtmxMiddleware.zig");
 pub const CompressionMiddleware = @import("middleware/CompressionMiddleware.zig");
 pub const AuthMiddleware = @import("middleware/AuthMiddleware.zig");
+pub const AntiCsrfMiddleware = @import("middleware/AntiCsrfMiddleware.zig");
 
 const RouteOptions = struct {
     content: ?[]const u8 = null,

--- a/src/jetzig/middleware/AntiCsrfMiddleware.zig
+++ b/src/jetzig/middleware/AntiCsrfMiddleware.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const jetzig = @import("../../jetzig.zig");
+
+pub const middleware_name = "anti_csrf";
+
+const TokenParams = @Type(.{
+    .@"struct" = .{
+        .layout = .auto,
+        .is_tuple = false,
+        .decls = &.{},
+        .fields = &.{.{
+            .name = jetzig.authenticity_token_name ++ "",
+            .type = []const u8,
+            .is_comptime = false,
+            .default_value = null,
+            .alignment = @alignOf([]const u8),
+        }},
+    },
+});
+
+pub fn afterRequest(request: *jetzig.http.Request) !void {
+    try verifyCsrfToken(request);
+}
+
+pub fn beforeRender(request: *jetzig.http.Request, route: jetzig.views.Route) !void {
+    _ = route;
+    try verifyCsrfToken(request);
+}
+
+fn logFailure(request: *jetzig.http.Request) !void {
+    _ = request.fail(.forbidden);
+    try request.server.logger.DEBUG("Anti-CSRF token validation failed. Request aborted.", .{});
+}
+
+fn verifyCsrfToken(request: *jetzig.http.Request) !void {
+    switch (request.method) {
+        .DELETE, .PATCH, .PUT, .POST => {},
+        else => return,
+    }
+
+    switch (request.requestFormat()) {
+        .HTML, .UNKNOWN => {},
+        // We do not authenticate JSON requests. Users must implement their own authentication
+        // system or disable JSON endpoints that should be protected.
+        .JSON => return,
+    }
+
+    const session = try request.session();
+
+    if (session.getT(.string, jetzig.authenticity_token_name)) |token| {
+        const params = try request.expectParams(TokenParams) orelse {
+            return logFailure(request);
+        };
+
+        if (token.len != 32 or @field(params, jetzig.authenticity_token_name).len != 32) {
+            return try logFailure(request);
+        }
+
+        var actual: [32]u8 = undefined;
+        var expected: [32]u8 = undefined;
+
+        @memcpy(&actual, token[0..32]);
+        @memcpy(&expected, @field(params, jetzig.authenticity_token_name)[0..32]);
+
+        const valid = std.crypto.timing_safe.eql([32]u8, expected, actual);
+
+        if (!valid) {
+            return try logFailure(request);
+        }
+    } else {
+        return try logFailure(request);
+    }
+}

--- a/src/jetzig/util.zig
+++ b/src/jetzig/util.zig
@@ -67,25 +67,25 @@ pub inline fn unquote(input: []const u8) []const u8 {
 }
 
 /// Generate a secure random string of `len` characters (for cryptographic purposes).
-pub fn generateSecret(allocator: std.mem.Allocator, comptime len: u10) ![]const u8 {
+pub fn generateSecret(allocator: std.mem.Allocator, len: u10) ![]const u8 {
     const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    var secret: [len]u8 = undefined;
+    const secret = try allocator.alloc(u8, len);
 
     for (0..len) |index| {
-        secret[index] = chars[std.crypto.random.intRangeAtMost(u8, 0, chars.len)];
+        secret[index] = chars[std.crypto.random.intRangeAtMost(u8, 0, chars.len - 1)];
     }
 
-    return try allocator.dupe(u8, &secret);
+    return secret;
 }
 
 pub fn generateRandomString(buf: []u8) []const u8 {
     const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
     for (0..buf.len) |index| {
-        buf[index] = chars[std.crypto.random.intRangeAtMost(u8, 0, chars.len)];
+        buf[index] = chars[std.crypto.random.intRangeAtMost(u8, 0, chars.len - 1)];
     }
 
-    return buf;
+    return buf[0..];
 }
 
 /// Calculate a duration from a given start time (in nanoseconds) to the current time.

--- a/src/jetzig/views/Route.zig
+++ b/src/jetzig/views/Route.zig
@@ -56,6 +56,8 @@ json_params: []const []const u8,
 params: std.ArrayList(*jetzig.data.Data) = undefined,
 id: []const u8,
 formats: ?Formats = null,
+before_callbacks: []const jetzig.callbacks.BeforeCallback = &.{},
+after_callbacks: []const jetzig.callbacks.AfterCallback = &.{},
 
 /// Initializes a route's static params on server launch. Converts static params (JSON strings)
 /// to `jetzig.data.Data` values. Memory is owned by caller (`App.start()`).


### PR DESCRIPTION
Add to middleware in app's `src/main.zig`:

```zig
pub const jetzig_options = struct {
    pub const middleware: []const type = &.{
        jetzig.middleware.AntiCsrfMiddleware,
    };
};
```

CSRF token available in Zmpl templates:

```
{{context.authenticityToken()}}
```
or render a hidden form element:
```
{{context.authenticityFormElement()}}
```

The following HTML requests are rejected (403 Forbidden) if the submitted query param does not match the value stored in the encrypted session (added automatically when the token is generated for a template value):

* POST
* PUT
* PATCH
* DELETE

JSON requests are not impacted - users should either disable JSON endpoints or implement a different authentication method to protect them.