### PR TITLE
Per-request database connection

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -15,8 +15,8 @@
             .hash = "12201d75d73aad5e1c996de4d5ae87a00e58479c8d469bc2eeb5fdeeac8857bc09af",
         },
         .jetquery = .{
-            .url = "https://github.com/jetzig-framework/jetquery/archive/f520d4bb3f7099f8d670926328c93efd8849c3cc.tar.gz",
-            .hash = "1220021eb5c36e78c1aafbf04a303433deb9fcb7edf29d8686b3bb33881884f2d23b",
+            .url = "https://github.com/jetzig-framework/jetquery/archive/52e1cf900c94f3c103727ade6ba2dab3057c8663.tar.gz",
+            .hash = "12208a37407d1a7548fd7e81d9f6a9d4897793918023ed559a279a7647dab2d43145",
         },
         .jetcommon = .{
             .url = "https://github.com/jetzig-framework/jetcommon/archive/86f24cfdf2aaa0e8ada4539a6edef882708ced2b.tar.gz",
@@ -27,8 +27,8 @@
             .hash = "1220411a8c46d95bbf3b6e2059854bcb3c5159d428814099df5294232b9980517e9c",
         },
         .pg = .{
-            .url = "https://github.com/karlseguin/pg.zig/archive/f376f4b30c63f1fdf90bc3afe246d3bc4175cd46.tar.gz",
-            .hash = "12200a55304988e942015b6244570b2dc0e87e5764719c9e7d5c812cd7ad34f6b138",
+            .url = "https://github.com/karlseguin/pg.zig/archive/0bfc46029c6a3e8ded7a3e0544fcbcb5baba2208.tar.gz",
+            .hash = "1220fb3f43073a6f9f201764c3ae78aa87b29edbc7b021c1174b29b020967d0b146c",
         },
         .smtp_client = .{
             .url = "https://github.com/karlseguin/smtp_client.zig/archive/3cbe8f269e4c3a6bce407e7ae48b2c76307c559f.tar.gz",

--- a/cli/build.zig.zon
+++ b/cli/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "1220411a8c46d95bbf3b6e2059854bcb3c5159d428814099df5294232b9980517e9c",
         },
         .jetquery = .{
-            .url = "https://github.com/jetzig-framework/jetquery/archive/f520d4bb3f7099f8d670926328c93efd8849c3cc.tar.gz",
-            .hash = "1220021eb5c36e78c1aafbf04a303433deb9fcb7edf29d8686b3bb33881884f2d23b",
+            .url = "https://github.com/jetzig-framework/jetquery/archive/52e1cf900c94f3c103727ade6ba2dab3057c8663.tar.gz",
+            .hash = "12208a37407d1a7548fd7e81d9f6a9d4897793918023ed559a279a7647dab2d43145",
         },
     },
     .paths = .{

--- a/src/commands/routes.zig
+++ b/src/commands/routes.zig
@@ -24,9 +24,10 @@ pub fn main() !void {
             .get => jetzig.colors.cyan("{s: <7}"),
             .index => jetzig.colors.blue("{s: <7}"),
             .new => jetzig.colors.green("{s: <7}"),
+            .edit => jetzig.colors.bold(.yellow, "{s: <7}"),
             .post => jetzig.colors.yellow("{s: <7}"),
             .put => jetzig.colors.magenta("{s: <7}"),
-            .patch => jetzig.colors.bright_magenta("{s: <7}"),
+            .patch => jetzig.colors.bold(.magenta, "{s: <7}"),
             .delete => jetzig.colors.red("{s: <7}"),
             .custom => unreachable,
         };
@@ -36,6 +37,7 @@ pub fn main() !void {
             route.uri_path ++ switch (route.action) {
                 .index, .post => "",
                 .new => "/new",
+                .edit => "/:id/edit",
                 .get, .put, .patch, .delete => "/:id",
                 .custom => "",
             },
@@ -54,7 +56,7 @@ pub fn main() !void {
 
     for (jetzig_app.custom_routes.items) |route| {
         log(
-            "  " ++ jetzig.colors.bold(jetzig.colors.white("{s: <7}")) ++ "  " ++ padded_path ++ " {s}:{s}",
+            "  " ++ jetzig.colors.bold(.white, "{s: <7}") ++ "  " ++ padded_path ++ " {s}:{s}",
             .{ route.name, route.uri_path, route.view_name, route.name },
         );
     }


### PR DESCRIPTION
Use JetQuery's new `Repo.bindConnect()` to get a new Repo bound to a connection for each request. This significantly simplifies connection management and offloads all the connection pool
management/reconnecting/etc. to pg.zig where it belongs.

Improve development mode SQL syntax highlighting - highlight `SELECT`, `UPDATE`, `DELETE`, `INSERT` in different bolded colors for clarity.