### PR TITLE
Fix email recipients

### DIFF
--- a/src/jetzig/http/Request.zig
+++ b/src/jetzig/http/Request.zig
@@ -582,17 +582,17 @@ const RequestMail = struct {
         var mail_job = try self.request.job("__jetzig_mail");
 
         try mail_job.params.put("mailer_name", self.name);
-        try mail_job.params.put("from", self.mail_params.from);
+        try mail_job.params.put("from", self.mail_params.get(.from));
 
         var to_array = try mail_job.data.array();
-        if (self.mail_params.to) |to| {
-            for (to) |each| try to_array.append(each);
+        if (self.mail_params.get(.to)) |to| {
+            for (to) |each| try to_array.append(.{ .email = each.email, .name = each.name });
         }
         try mail_job.params.put("to", to_array);
 
-        try mail_job.params.put("subject", self.mail_params.subject);
-        try mail_job.params.put("html", self.mail_params.html);
-        try mail_job.params.put("text", self.mail_params.text);
+        try mail_job.params.put("subject", self.mail_params.get(.subject));
+        try mail_job.params.put("html", self.mail_params.get(.html));
+        try mail_job.params.put("text", self.mail_params.get(.text));
 
         if (self.request.response_data.value) |value| try mail_job.params.put(
             "params",

--- a/src/jetzig/mail/Job.zig
+++ b/src/jetzig/mail/Job.zig
@@ -46,8 +46,11 @@ pub fn run(allocator: std.mem.Allocator, params: *jetzig.data.Value, env: jetzig
 
     if (env.environment == .development and !jetzig.config.get(bool, "force_development_email_delivery")) {
         try env.logger.INFO(
-            "Skipping mail delivery in development environment:\n{s}",
-            .{try mail.generateData()},
+            \\Skipping mail delivery in development environment:
+            \\To: {?s}
+            \\{s}
+        ,
+            .{ mail.params.get(.to), try mail.generateData() },
         );
     } else {
         try mail.deliver();
@@ -87,8 +90,8 @@ fn resolveTo(allocator: std.mem.Allocator, params: *const jetzig.data.Value) !?[
                 .null => null,
                 .string => |string| .{ .email = string.value },
                 .object => |object| .{
-                    .email = object.getT(.string, "email") orelse return null,
-                    .name = object.getT(.string, "name") orelse return null,
+                    .email = object.getT(.string, "email") orelse return error.JetzigMissingEmailField,
+                    .name = object.getT(.string, "name"),
                 },
                 else => unreachable,
             };


### PR DESCRIPTION
Prevent breaking out of "To" recipient resolving when `name` is null - this is a valid value as we only need the `email` field to deliver an email successfully.