### PR TITLE
Fix memory leak in CLI

### DIFF
--- a/cli/util.zig
+++ b/cli/util.zig
@@ -222,7 +222,9 @@ pub fn runCommandInDir(allocator: std.mem.Allocator, argv: []const []const u8, d
         }
         return error.JetzigCommandError;
     } else {
-        printSuccess(try std.mem.join(allocator, " ", argv));
+        const message = try std.mem.join(allocator, " ", argv);
+        defer allocator.free(message);
+        printSuccess(message);
     }
 }
 


### PR DESCRIPTION
This fixes a memory leak in the CLI, the message was being allocated but never deallocated anywhere.

Fixes #167 