### PR TITLE
Fix anonymous struct literal in log_thread spawn

### DIFF
--- a/src/jetzig/App.zig
+++ b/src/jetzig/App.zig
@@ -62,7 +62,7 @@ pub fn start(self: *const App, routes_module: type, options: AppOptions) !void {
     var log_thread = try std.Thread.spawn(
         .{ .allocator = self.allocator },
         jetzig.loggers.LogQueue.Reader.publish,
-        .{ &self.env.log_queue.reader, .{} },
+        .{ &self.env.log_queue.reader, jetzig.loggers.LogQueue.Reader.PublishOptions{} },
     );
     defer log_thread.join();
 

--- a/src/jetzig/loggers/LogQueue.zig
+++ b/src/jetzig/loggers/LogQueue.zig
@@ -147,9 +147,13 @@ pub const Reader = struct {
     stderr_file: std.fs.File,
     queue: *LogQueue,
 
+    pub const PublishOptions = struct {
+        oneshot: bool = false,
+    };
+
     /// Publish log events from the queue. Invoke from a dedicated thread. Sleeps when log queue
     /// is empty, wakes up when a new event is published.
-    pub fn publish(self: *Reader, options: struct { oneshot: bool = false }) !void {
+    pub fn publish(self: *Reader, options: PublishOptions) !void {
         std.debug.assert(self.queue.state == .ready);
 
         const stdout_writer = self.stdout_file.writer();


### PR DESCRIPTION
I believe this change is needed due to this: https://ziglang.org/download/0.14.0/release-notes.html#Remove-Anonymous-Struct-Types-Unify-Tuples

I fixed it by declaring a non-anonymous struct type for this parameter, which allows to use it in `Thread.spawn`. I believe this is due to type coercion not being able to work in this specific case but I might be mistaken. 