### PR TITLE
Uses specific version as Zig nightly breaks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
       # uses: goto-bus-stop/setup-zig@41ae19e72e21b9a1380e86ff9f058db709fc8fc6
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: master
+          version: 0.14.0
           cache: true # Let's see how this behaves
 
       - run: zig version


### PR DESCRIPTION
Uses the specific latest Zig version at the moment as nightly breaks. 

This also fixes the broken [Jetzig binaries at Download page](https://www.jetzig.dev/downloads.html).

Can switch to `version: latest` as https://github.com/goto-bus-stop/setup-zig/pull/90 is merged.