### PR TITLE
Switches zig-setup workflow allowing building on latest stable Zig

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,12 +24,9 @@ jobs:
           submodules: true
 
       - name: Setup Zig
-      # You may pin to the exact commit or the version.
-      # uses: goto-bus-stop/setup-zig@41ae19e72e21b9a1380e86ff9f058db709fc8fc6
-        uses: goto-bus-stop/setup-zig@v2
+        uses: mlugg/setup-zig@v1
         with:
-          version: master
-          cache: true # Let's see how this behaves
+          version: latest
 
       - run: zig version
       - run: zig env


### PR DESCRIPTION
Previous workflow uses:
* nightly Zig version which unforutnately is breaking
* workflow step that is unmaintained

This should also fix the broken [Jetzig binaries at Download page](https://www.jetzig.dev/downloads.html).

Replaces https://github.com/jetzig-framework/jetzig/pull/175