### PR TITLE
Defines minimum supported Zig version.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
-        with:
-          version: master
 
       - run: zig version
       - run: zig env

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
+        with:
+          version: 0.15.0-dev.345+ec2888858
 
       - run: zig version
       - run: zig env

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,6 +2,7 @@
     .name = .jetzig,
     .version = "0.0.0",
     .fingerprint = 0x93ad8bfa2d209022,
+    .minimum_zig_version = "0.15.0-dev.345+ec2888858",
     .dependencies = .{
         .jetcommon = .{
             .url = "https://github.com/jetzig-framework/jetcommon/archive/fb4edc13759d87bfcd9b1f5fcefdf93f8c9c62dd.tar.gz",


### PR DESCRIPTION
Defines a consistent minimum supported Zig version, also updated CI to test against the minimum version.

This adds some form of consistency following #185 now that we are beyond stable releases. 

