### PR TITLE
CI now uses minimum_zig_version as defined in build.zig.zon

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,9 +28,7 @@ jobs:
           submodules: true
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v1
-        with:
-          version: 0.15.0-dev.345+ec2888858
+        uses: mlugg/setup-zig@main
 
       - run: zig version
       - run: zig env


### PR DESCRIPTION
To avoid repetition, CI now sets up Zig as defined in `minimum_zig_version` in `build.zig.zon`.

Earlier PR failed because:
1. I was not aware that GitHub Actions does not do semver.
2. This feature is [still unreleased](https://github.com/mlugg/setup-zig/issues/16) but working.