### PR TITLE
Overriding of default session cookie name

### DIFF
--- a/demo/src/app/views/anti_csrf/index.zmpl
+++ b/demo/src/app/views/anti_csrf/index.zmpl
@@ -7,4 +7,4 @@
     <input type="submit" value="Submit Spam" />
 </form>
 
-<div>Try clearing `_jetzig_session` cookie before clicking "Submit Spam"</div>
+<div>Try clearing `_jetzig-session` cookie before clicking "Submit Spam"</div>

--- a/src/jetzig/http/Request.zig
+++ b/src/jetzig/http/Request.zig
@@ -497,12 +497,14 @@ pub fn cookies(self: *Request) !*jetzig.http.Cookies {
 /// `jetzig.http.Session`.
 pub fn session(self: *Request) !*jetzig.http.Session {
     if (self._session) |capture| return capture;
-
+    const cookie_name = self.server.env.vars.get("JETZIG_SESSION_COOKIE") orelse
+        jetzig.http.Session.default_cookie_name;
     const local_session = try self.allocator.create(jetzig.http.Session);
     local_session.* = jetzig.http.Session.init(
         self.allocator,
         try self.cookies(),
         self.server.env.secret,
+        .{ .cookie_name = cookie_name },
     );
     local_session.parse() catch |err| {
         switch (err) {

--- a/src/jetzig/http/Session.zig
+++ b/src/jetzig/http/Session.zig
@@ -15,19 +15,23 @@ state: enum { parsed, pending } = .pending,
 
 const Self = @This();
 
+pub const default_cookie_name = "_jetzig-session";
+
+pub const Options = struct {
+    cookie_name: []const u8 = default_cookie_name,
+};
+
 pub fn init(
     allocator: std.mem.Allocator,
     cookies: *jetzig.http.Cookies,
     encryption_key: []const u8,
+    options: Options,
 ) Self {
-    const env_cookie_name = std.process.getEnvVarOwned(allocator, "JETZIG_SESSION_COOKIE") catch null;
-    const cookie_name = env_cookie_name orelse "_jetzig-session";
-
     return .{
         .allocator = allocator,
         .data = jetzig.data.Data.init(allocator),
         .cookies = cookies,
-        .cookie_name = cookie_name,
+        .cookie_name = options.cookie_name,
         .encryption_key = encryption_key,
     };
 }
@@ -184,7 +188,7 @@ test "put and get session key/value" {
     try cookies.parse();
 
     const secret: [Cipher.key_length]u8 = [_]u8{0x69} ** Cipher.key_length;
-    var session = Self.init(allocator, &cookies, &secret);
+    var session = Self.init(allocator, &cookies, &secret, .{});
     defer session.deinit();
 
     var data = jetzig.data.Data.init(allocator);
@@ -203,7 +207,7 @@ test "remove session key/value" {
     try cookies.parse();
 
     const secret: [Cipher.key_length]u8 = [_]u8{0x69} ** Cipher.key_length;
-    var session = Self.init(allocator, &cookies, &secret);
+    var session = Self.init(allocator, &cookies, &secret, .{});
     defer session.deinit();
 
     var data = jetzig.data.Data.init(allocator);
@@ -228,7 +232,7 @@ test "get value from parsed/decrypted cookie" {
     try cookies.parse();
 
     const secret: [Cipher.key_length]u8 = [_]u8{0x69} ** Cipher.key_length;
-    var session = Self.init(allocator, &cookies, &secret);
+    var session = Self.init(allocator, &cookies, &secret, .{});
     defer session.deinit();
 
     try session.parse();
@@ -238,16 +242,31 @@ test "get value from parsed/decrypted cookie" {
 
 test "invalid cookie value - too short" {
     const allocator = std.testing.allocator;
+    var cookies = jetzig.http.Cookies.init(allocator, "_jetzig-session=abc");
+    defer cookies.deinit();
+    try cookies.parse();
+
+    const secret: [Cipher.key_length]u8 = [_]u8{0x69} ** Cipher.key_length;
+    var session = Self.init(allocator, &cookies, &secret, .{});
+    defer session.deinit();
+
+    try std.testing.expectError(error.JetzigInvalidSessionCookie, session.parse());
+}
+
+test "custom session cookie name" {
+    const allocator = std.testing.allocator;
     var cookies = jetzig.http.Cookies.init(
         allocator,
-        "_jetzig-session=abc",
+        "custom-cookie-name=fPCFwZHvPDT-XCVcsQUSspDLchS3tRuJDqPpB2v3127VXpRP_bPcPLgpHK6RiVkfcP1bMtU",
     );
     defer cookies.deinit();
     try cookies.parse();
 
     const secret: [Cipher.key_length]u8 = [_]u8{0x69} ** Cipher.key_length;
-    var session = Self.init(allocator, &cookies, &secret);
+    var session = Self.init(allocator, &cookies, &secret, .{ .cookie_name = "custom-cookie-name" });
     defer session.deinit();
 
-    try std.testing.expectError(error.JetzigInvalidSessionCookie, session.parse());
+    try session.parse();
+    var value = (session.get("foo")).?;
+    try std.testing.expectEqualStrings("bar", try value.toString());
 }

--- a/src/jetzig/testing/App.zig
+++ b/src/jetzig/testing/App.zig
@@ -55,7 +55,7 @@ pub fn init(allocator: std.mem.Allocator, routes_module: type) !App {
     try cookies.parse();
 
     const session = try alloc.create(jetzig.http.Session);
-    session.* = jetzig.http.Session.init(alloc, cookies, jetzig.testing.secret);
+    session.* = jetzig.http.Session.init(alloc, cookies, jetzig.testing.secret, .{});
 
     app.* = App{
         .arena = arena,
@@ -237,7 +237,7 @@ pub fn initSession(self: *App) !void {
     const allocator = self.arena.allocator();
 
     var local_session = try allocator.create(jetzig.http.Session);
-    local_session.* = jetzig.http.Session.init(allocator, self.cookies, jetzig.testing.secret);
+    local_session.* = jetzig.http.Session.init(allocator, self.cookies, jetzig.testing.secret, .{});
     try local_session.parse();
 
     self.session = local_session;


### PR DESCRIPTION
Allowing overriding of default session cookie name just for general good practice. 

To override, set env var `JETZIG_SESSION_COOKIE`:

```sh
export JETZIG_SESSION_COOKIE=myapp
```

WIll update documentation if this is accepted. WIll perhaps write a documentation on Session. Can't seem to find one at https://www.jetzig.dev/documentation.html