### PR TITLE
Implement `request.renderText()`

### DIFF
--- a/demo/src/app/views/render_text.zig
+++ b/demo/src/app/views/render_text.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+const jetzig = @import("jetzig");
+
+pub fn index(request: *jetzig.Request) !jetzig.View {
+    request.response.content_type = "text/xml";
+    return request.renderText("<foo><bar>baz</bar></foo>", .ok);
+}
+
+test "index" {
+    var app = try jetzig.testing.app(std.testing.allocator, @import("routes"));
+    defer app.deinit();
+
+    const response = try app.request(.GET, "/render_text", .{});
+    try response.expectStatus(.ok);
+    try response.expectBodyContains("<foo><bar>baz</bar></foo>");
+    try response.expectHeader("content-type", "text/xml");
+}

--- a/demo/src/app/views/render_text/index.zmpl
+++ b/demo/src/app/views/render_text/index.zmpl
@@ -1,0 +1,3 @@
+<div>
+  <span>Content goes here</span>
+</div>

--- a/src/jetzig/http.zig
+++ b/src/jetzig/http.zig
@@ -26,3 +26,5 @@ pub const params = @import("http/params.zig");
 pub const SimplifiedRequest = struct {
     location: ?[]const u8,
 };
+
+pub const default_content_type = "application/octet-stream";

--- a/src/jetzig/http/Request.zig
+++ b/src/jetzig/http/Request.zig
@@ -16,6 +16,7 @@ pub const RequestState = enum {
     processed, // Request headers have been processed
     after_request, // Initial middleware processing
     rendered, // Rendered by middleware or view
+    rendered_text, // Rendered text by middleware or view
     redirected, // Redirected by middleware or view
     failed, // Failed by middleware or view
     before_response, // Post middleware processing
@@ -230,7 +231,7 @@ pub fn fail(self: *Request, status_code: jetzig.http.status_codes.StatusCode) je
 pub inline fn isRendered(self: *const Request) bool {
     return switch (self.state) {
         .initial, .processed, .after_request, .before_response => false,
-        .rendered, .redirected, .failed, .finalized => true,
+        .rendered, .rendered_text, .redirected, .failed, .finalized => true,
     };
 }
 
@@ -736,6 +737,18 @@ pub fn joinPath(self: *const Request, args: anytype) ![]const u8 {
     return try std.mem.join(self.allocator, "/", buf[0..]);
 }
 
+pub fn renderText(
+    self: *Request,
+    text: []const u8,
+    status_code: jetzig.http.StatusCode,
+) jetzig.views.View {
+    self.state = .rendered_text;
+    self.rendered_view = .{ .data = self.response_data, .status_code = status_code };
+    self.setResponse(.{ .view = self.rendered_view.?, .content = text }, .{});
+
+    return self.rendered_view.?;
+}
+
 pub fn joinPaths(self: *const Request, paths: []const []const []const u8) ![]const u8 {
     var buf = std.ArrayList([]const u8).init(self.allocator);
     defer buf.deinit();
@@ -753,10 +766,12 @@ pub fn setResponse(
 ) void {
     self.response.content = rendered_view.content;
     self.response.status_code = rendered_view.view.status_code;
-    self.response.content_type = options.content_type orelse switch (self.requestFormat()) {
-        .HTML, .UNKNOWN => "text/html",
-        .JSON => "application/json",
-    };
+    if (self.response.content_type == null) {
+        self.response.content_type = options.content_type orelse switch (self.requestFormat()) {
+            .HTML, .UNKNOWN => "text/html",
+            .JSON => "application/json",
+        };
+    }
 }
 
 fn setCookieHeaders(self: *Request) !void {

--- a/src/jetzig/http/Response.zig
+++ b/src/jetzig/http/Response.zig
@@ -11,7 +11,7 @@ allocator: std.mem.Allocator,
 headers: jetzig.http.Headers,
 content: []const u8,
 status_code: http.status_codes.StatusCode,
-content_type: []const u8,
+content_type: ?[]const u8 = null,
 httpz_response: *httpz.Response,
 
 pub fn init(
@@ -22,8 +22,11 @@ pub fn init(
         .allocator = allocator,
         .httpz_response = httpz_response,
         .status_code = .no_content,
-        .content_type = "application/octet-stream",
         .content = "",
         .headers = jetzig.http.Headers.init(allocator, &httpz_response.headers),
     };
+}
+
+pub inline fn contentType(self: *const jetzig.http.Response) []const u8 {
+    return self.content_type orelse jetzig.http.default_content_type;
 }


### PR DESCRIPTION
Render a text string (+ status code) directly.