### PR TITLE
Public routing path

### DIFF
--- a/demo/src/main.zig
+++ b/demo/src/main.zig
@@ -66,6 +66,10 @@ pub const jetzig_options = struct {
     // Path relative to cwd() to serve public content from. Symlinks are not followed.
     pub const public_content_path = "public";
 
+    /// Request path to map to public directory, e.g. if `public_routing_path` is `"/foo"` then a
+    /// request to `/foo/bar.png` will serve static content found in `public/bar.png`
+    pub const public_routing_path = "/";
+
     // HTTP buffer. Must be large enough to store all headers. This should typically not be modified.
     pub const http_buffer_size: usize = std.math.pow(usize, 2, 16);
 

--- a/src/jetzig/config.zig
+++ b/src/jetzig/config.zig
@@ -84,6 +84,10 @@ pub const max_connections: u16 = 512;
 /// Path relative to cwd() to serve public content from. Symlinks are not followed.
 pub const public_content_path = "public";
 
+/// Request path to map to public directory, e.g. if `public_routing_path` is `"/foo"` then a
+/// request to `/foo/bar.png` will serve static content found in `public/bar.png`
+pub const public_routing_path = "/";
+
 /// Middleware chain. Add any custom middleware here, or use middleware provided in
 /// `jetzig.middleware` (e.g. `jetzig.middleware.HtmxMiddleware`).
 pub const middleware = &.{};


### PR DESCRIPTION
Set `public_routing_path` config option to specify a request path prefix for public requests.