### PR TITLE
Initialized project uses layout

### DIFF
--- a/cli/commands/init.zig
+++ b/cli/commands/init.zig
@@ -156,6 +156,14 @@ pub fn run(
     try copySourceFile(
         allocator,
         install_dir,
+        "demo/src/app/views/layouts/default.zmpl",
+        "src/app/views/layouts/default.zmpl",
+        null,
+    );
+
+    try copySourceFile(
+        allocator,
+        install_dir,
         "demo/public/jetzig.png",
         "public/jetzig.png",
         null,

--- a/cli/compile.zig
+++ b/cli/compile.zig
@@ -26,6 +26,7 @@ pub fn initDataModule(build: *std.Build) !*std.Build.Module {
         "demo/src/app/views/init.zig",
         "demo/src/app/views/init/index.zmpl",
         "demo/src/app/views/init/_content.zmpl",
+        "demo/src/app/views/layouts/default.zmpl",
         "demo/public/jetzig.png",
         "demo/public/zmpl.png",
         "demo/public/favicon.ico",

--- a/demo/src/app/views/init.zig
+++ b/demo/src/app/views/init.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const jetzig = @import("jetzig");
 
+pub const layout = "default";
+
 /// `src/app/views/root.zig` represents the root URL `/`
 /// The `index` view function is invoked when when the HTTP verb is `GET`.
 /// Other view types are invoked either by passing a resource ID value (e.g. `/1234`) or by using

--- a/demo/src/app/views/init/index.zmpl
+++ b/demo/src/app/views/init/index.zmpl
@@ -1,22 +1,10 @@
-<html>
-  <head>
-    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+<div class="text-center pt-10 m-auto">
+  <!-- If present, renders the `message_param` response data value, add `?message=hello` to the
+       URL to see the output: -->
+  <h2 class="param text-3xl text-[#f7931e]">{{$.message_param}}</h2>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="/styles.css" />
-  </head>
-
-  <body>
-    <div class="text-center pt-10 m-auto">
-      <!-- If present, renders the `message_param` response data value, add `?message=hello` to the
-           URL to see the output: -->
-      <h2 class="param text-3xl text-[#f7931e]">{{$.message_param}}</h2>
-
-      <!-- Renders `src/app/views/init/_content.zmpl`, passing in the `welcome_message` field from template data. -->
-      <div>
-        @partial init/content(message: $.welcome_message)
-      </div>
-    </div>
-  </body>
-</html>
+  <!-- Renders `src/app/views/init/_content.zmpl`, passing in the `welcome_message` field from template data. -->
+  <div>
+    @partial init/content(message: $.welcome_message)
+  </div>
+</div>

--- a/demo/src/app/views/layouts/default.zmpl
+++ b/demo/src/app/views/layouts/default.zmpl
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="/styles.css" />
+    <title>Jetzig App</title>
+  </head>
+
+  <body>
+    {{zmpl.content}}
+  </body>
+</html>


### PR DESCRIPTION
New users can learn about layout from initialized project via `jetzig init` rather than having to discover it through documentation, besides it can be a better boilerplate to an actual project.
